### PR TITLE
#67 fix: report accurate fixable_count for advisory-only analyzers

### DIFF
--- a/src/analyzers/empty_lines.rs
+++ b/src/analyzers/empty_lines.rs
@@ -85,7 +85,7 @@ impl EmptyLinesAnalyzer {
                     column:  1,
                     message: "Empty line in function body indicates untamed complexity"
                         .to_string(),
-                    fix:     Fix::Simple(String::new())
+                    fix:     Fix::None
                 });
             }
         }
@@ -190,11 +190,9 @@ impl Analyzer for EmptyLinesAnalyzer {
         };
         visitor.visit_file(ast);
 
-        let fixable_count = visitor.issues.len();
-
         Ok(AnalysisResult {
-            issues: visitor.issues,
-            fixable_count
+            issues:        visitor.issues,
+            fixable_count: 0
         })
     }
 
@@ -331,7 +329,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fixable_count() {
+    fn test_advisory_only_not_fixable() {
         let analyzer = EmptyLinesAnalyzer::new();
         let content = r#"fn main() {
     let x = 1;
@@ -341,8 +339,9 @@ mod tests {
         let code = syn::parse_str(content).unwrap();
 
         let result = analyzer.analyze(&code, content).unwrap();
-        assert_eq!(result.fixable_count, 1);
+        assert_eq!(result.fixable_count, 0);
         assert_eq!(result.issues.len(), 1);
+        assert!(!result.issues[0].fix.is_available());
     }
 
     #[test]

--- a/src/analyzers/format_args.rs
+++ b/src/analyzers/format_args.rs
@@ -53,11 +53,9 @@ impl Analyzer for FormatArgsAnalyzer {
         };
         syn::visit::visit_file(&mut visitor, ast);
 
-        let fixable_count = visitor.issues.len();
-
         Ok(AnalysisResult {
-            issues: visitor.issues,
-            fixable_count
+            issues:        visitor.issues,
+            fixable_count: 0
         })
     }
 
@@ -127,6 +125,21 @@ mod tests {
 
         let result = analyzer.analyze(&code, "").unwrap();
         assert!(!result.issues.is_empty());
+    }
+
+    #[test]
+    fn test_advisory_only_not_fixable() {
+        let analyzer = FormatArgsAnalyzer::new();
+        let code: File = parse_quote! {
+            fn main() {
+                println!("Values: {} {} {}", 1, 2, 3);
+            }
+        };
+
+        let result = analyzer.analyze(&code, "").unwrap();
+        assert!(!result.issues.is_empty());
+        assert_eq!(result.fixable_count, 0);
+        assert!(!result.issues[0].fix.is_available());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`check` inflated `Fixable: N` with issues no analyzer applies. `format_args` and `empty_lines` are detection-only hints, yet counted themselves as fixable (and `empty_lines` produced a no-op empty→empty diff entry).

## Changes

- `format_args`: `fixable_count = 0`.
- `empty_lines`: emit `Fix::None` and `fixable_count = 0` (kept as a refactoring hint).
- Tests assert these issues are not fixable.

Now `check`/`diff`/`fix` agree — only path_import and mod_rs count as fixable.

## Verification

`cargo test` (392), `cargo clippy --all-targets --all-features` — green.

Closes #67