### PR TITLE
#73 fix: count format placeholders accurately in format_args analyzer

### DIFF
--- a/src/analyzers/format_args.rs
+++ b/src/analyzers/format_args.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 use masterror::AppResult;
-use syn::{ExprMacro, File, Macro, spanned::Spanned};
+use proc_macro2::TokenTree;
+use syn::{ExprMacro, File, LitStr, Macro, spanned::Spanned};
 
 use crate::analyzer::{AnalysisResult, Analyzer, Fix, Issue};
 
@@ -16,29 +17,109 @@ impl FormatArgsAnalyzer {
     }
 
     fn analyze_format_macro(mac: &Macro) -> Option<Issue> {
-        let tokens = &mac.tokens;
-        let token_str = tokens.to_string();
+        let format = Self::extract_format_string(mac)?;
+        let placeholder_count = Self::count_positional_placeholders(&format);
 
-        if token_str.contains("{}") {
-            let placeholder_count = token_str.matches("{}").count();
+        if placeholder_count >= 3 {
+            let span = mac.span();
+            let start = span.start();
 
-            if placeholder_count >= 3 {
-                let span = mac.span();
-                let start = span.start();
+            return Some(Issue {
+                line:    start.line,
+                column:  start.column,
+                message: format!(
+                    "Use named format arguments for better readability ({} placeholders)",
+                    placeholder_count
+                ),
+                fix:     Fix::None
+            });
+        }
 
-                return Some(Issue {
-                    line:    start.line,
-                    column:  start.column,
-                    message: format!(
-                        "Use named format arguments for better readability ({} placeholders)",
-                        placeholder_count
-                    ),
-                    fix:     Fix::None
-                });
+        None
+    }
+
+    /// Extract the format string literal from macro tokens.
+    ///
+    /// Returns the unescaped value of the first top-level string literal, which
+    /// is the format string for both `print`/`format` and `write`/`writeln`
+    /// families (the writer argument is not a string literal).
+    ///
+    /// # Arguments
+    ///
+    /// * `mac` - Macro invocation to inspect
+    ///
+    /// # Returns
+    ///
+    /// `Some(String)` with the format string value, or `None` if absent
+    fn extract_format_string(mac: &Macro) -> Option<String> {
+        for token in mac.tokens.clone() {
+            if let TokenTree::Literal(literal) = token
+                && let Ok(lit_str) = syn::parse_str::<LitStr>(&literal.to_string())
+            {
+                return Some(lit_str.value());
             }
         }
 
         None
+    }
+
+    /// Count positional placeholders in a format string.
+    ///
+    /// Counts `{}`, indexed `{0}`, and spec-only `{:?}` placeholders. Named
+    /// placeholders such as `{name}` or `{name:spec}` are ignored, and
+    /// `{{`/`}}` are treated as escapes.
+    ///
+    /// # Arguments
+    ///
+    /// * `format` - Unescaped format string value
+    ///
+    /// # Returns
+    ///
+    /// Number of positional placeholders
+    fn count_positional_placeholders(format: &str) -> usize {
+        let bytes = format.as_bytes();
+        let mut count = 0;
+        let mut index = 0;
+
+        while index < bytes.len() {
+            match bytes[index] {
+                b'{' => {
+                    if bytes.get(index + 1) == Some(&b'{') {
+                        index += 2;
+                        continue;
+                    }
+
+                    let name_start = index + 1;
+                    let mut name_end = name_start;
+                    while name_end < bytes.len()
+                        && bytes[name_end] != b'}'
+                        && bytes[name_end] != b':'
+                    {
+                        name_end += 1;
+                    }
+
+                    let name = &format[name_start..name_end];
+                    if name.is_empty() || name.bytes().all(|b| b.is_ascii_digit()) {
+                        count += 1;
+                    }
+
+                    while index < bytes.len() && bytes[index] != b'}' {
+                        index += 1;
+                    }
+                    index += 1;
+                }
+                b'}' => {
+                    index += if bytes.get(index + 1) == Some(&b'}') {
+                        2
+                    } else {
+                        1
+                    };
+                }
+                _ => index += 1
+            }
+        }
+
+        count
     }
 }
 
@@ -256,5 +337,78 @@ mod tests {
 
         let result = analyzer.analyze(&code, "").unwrap();
         assert_eq!(result.issues.len(), 0);
+    }
+
+    #[test]
+    fn test_count_debug_and_spec_placeholders() {
+        let analyzer = FormatArgsAnalyzer::new();
+        let code: File = parse_quote! {
+            fn main() {
+                println!("{} {} {:?}", a, b, c);
+            }
+        };
+
+        let result = analyzer.analyze(&code, "").unwrap();
+        assert_eq!(result.issues.len(), 1);
+        assert!(result.issues[0].message.contains("3 placeholders"));
+    }
+
+    #[test]
+    fn test_ignore_named_placeholders_over_threshold() {
+        let analyzer = FormatArgsAnalyzer::new();
+        let code: File = parse_quote! {
+            fn main() {
+                println!("{a} {b} {c}", a = 1, b = 2, c = 3);
+            }
+        };
+
+        let result = analyzer.analyze(&code, "").unwrap();
+        assert_eq!(result.issues.len(), 0);
+    }
+
+    #[test]
+    fn test_escaped_braces_not_counted() {
+        let analyzer = FormatArgsAnalyzer::new();
+        let code: File = parse_quote! {
+            fn main() {
+                println!("{{}} {{}} {{}} {}", x);
+            }
+        };
+
+        let result = analyzer.analyze(&code, "").unwrap();
+        assert_eq!(result.issues.len(), 0);
+    }
+
+    #[test]
+    fn test_indexed_placeholders_counted() {
+        let analyzer = FormatArgsAnalyzer::new();
+        let code: File = parse_quote! {
+            fn main() {
+                println!("{0} {1} {2}", a, b, c);
+            }
+        };
+
+        let result = analyzer.analyze(&code, "").unwrap();
+        assert_eq!(result.issues.len(), 1);
+    }
+
+    #[test]
+    fn test_count_positional_placeholders_helper() {
+        assert_eq!(
+            FormatArgsAnalyzer::count_positional_placeholders("{} {} {:?}"),
+            3
+        );
+        assert_eq!(
+            FormatArgsAnalyzer::count_positional_placeholders("{a} {b} {c}"),
+            0
+        );
+        assert_eq!(
+            FormatArgsAnalyzer::count_positional_placeholders("{{}} literal {}"),
+            1
+        );
+        assert_eq!(
+            FormatArgsAnalyzer::count_positional_placeholders("{0} {1:>8} {2:.2}"),
+            3
+        );
     }
 }


### PR DESCRIPTION
## Summary

Placeholder counting used `token_str.matches("{}")` over the raw token stream, so `{:?}`/`{:>8}`/`{0}` were missed, `{{`/`}}` escapes were mishandled, and non-format-string tokens were scanned.

## Changes

- `extract_format_string`: take the unescaped value of the first top-level string literal (works for print/format and write/writeln).
- `count_positional_placeholders`: count `{}`, indexed `{0}`, and spec-only `{:?}`; skip named `{name}`/`{name:spec}`; treat `{{`/`}}` as escapes.
- Keep the `>= 3` threshold.

## Verification

New tests cover `{:?}`, escapes, named args, indexed args, and the helper directly. `cargo test` (398), `cargo clippy --all-targets --all-features` — green.

Closes #73