### PR TITLE
#75 fix: apply selected changes in interactive diff

### DIFF
--- a/src/differ.rs
+++ b/src/differ.rs
@@ -7,10 +7,12 @@
 //! width, offering vertical layout for narrow terminals and side-by-side for
 //! wider displays.
 
+pub mod apply;
 pub mod display;
 mod generator;
 pub mod types;
 
+pub use apply::apply_diff;
 pub use display::{show_full, show_interactive, show_summary};
 pub use generator::generate_diff;
 pub use types::DiffResult;

--- a/src/differ/apply.rs
+++ b/src/differ/apply.rs
@@ -1,0 +1,240 @@
+// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! Application of selected diff entries to files on disk.
+//!
+//! Used by interactive mode to write only the changes the user accepted.
+//! Line replacements are keyed by line number and guarded by an equality check
+//! against the recorded original, so a change is skipped if the file no longer
+//! matches what the diff was generated from.
+
+use std::fs;
+
+use masterror::AppResult;
+
+use super::types::{DiffResult, FileDiff};
+use crate::error::IoError;
+
+/// Applies selected diff entries to their files.
+///
+/// For each file, replaces recorded lines with their modified form and inserts
+/// deduplicated `use` imports after leading module docs and inner attributes.
+///
+/// # Arguments
+///
+/// * `result` - Selected diff entries grouped by file
+///
+/// # Returns
+///
+/// `AppResult<usize>` - Number of line changes written across all files
+///
+/// # Errors
+///
+/// Returns an error if reading or writing a file fails.
+pub fn apply_diff(result: &DiffResult) -> AppResult<usize> {
+    let mut applied = 0;
+
+    for file in &result.files {
+        applied += apply_file(file)?;
+    }
+
+    Ok(applied)
+}
+
+/// Applies the entries of a single file diff.
+///
+/// # Arguments
+///
+/// * `file` - File diff with the entries to apply
+///
+/// # Returns
+///
+/// `AppResult<usize>` - Number of line changes written for this file
+fn apply_file(file: &FileDiff) -> AppResult<usize> {
+    if file.entries.is_empty() {
+        return Ok(0);
+    }
+
+    let content = fs::read_to_string(&file.path).map_err(IoError::from)?;
+    let mut lines: Vec<String> = content.lines().map(str::to_string).collect();
+    let mut imports: Vec<String> = Vec::new();
+    let mut applied = 0;
+
+    for entry in &file.entries {
+        let idx = entry.line.saturating_sub(1);
+
+        let Some(line) = lines.get_mut(idx) else {
+            continue;
+        };
+
+        if *line != entry.original {
+            continue;
+        }
+
+        *line = entry.modified.clone();
+
+        if let Some(import) = &entry.import
+            && !imports.contains(import)
+        {
+            imports.push(import.clone());
+        }
+
+        applied += 1;
+    }
+
+    if applied == 0 {
+        return Ok(0);
+    }
+
+    insert_imports(&mut lines, imports);
+
+    let mut text = lines.join("\n");
+    if content.ends_with('\n') {
+        text.push('\n');
+    }
+
+    fs::write(&file.path, text).map_err(IoError::from)?;
+
+    Ok(applied)
+}
+
+/// Inserts import lines after leading module docs and inner attributes.
+///
+/// Skips a leading run of blank lines, non-doc `//` comments, module docs
+/// (`//!`), and inner attributes (`#!`) so the imports remain valid Rust.
+///
+/// # Arguments
+///
+/// * `lines` - File lines to modify in place
+/// * `imports` - Deduplicated import statements to insert
+fn insert_imports(lines: &mut Vec<String>, imports: Vec<String>) {
+    if imports.is_empty() {
+        return;
+    }
+
+    let mut insert_at = 0;
+    for (index, line) in lines.iter().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.is_empty()
+            || trimmed.starts_with("//!")
+            || trimmed.starts_with("#!")
+            || (trimmed.starts_with("//") && !trimmed.starts_with("///"))
+        {
+            insert_at = index + 1;
+        } else {
+            break;
+        }
+    }
+
+    for (offset, import) in imports.into_iter().enumerate() {
+        lines.insert(insert_at + offset, import);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::differ::types::DiffEntry;
+
+    fn entry(line: usize, original: &str, modified: &str, import: Option<&str>) -> DiffEntry {
+        DiffEntry {
+            line,
+            analyzer: "path_import".to_string(),
+            original: original.to_string(),
+            modified: modified.to_string(),
+            description: "desc".to_string(),
+            import: import.map(str::to_string)
+        }
+    }
+
+    #[test]
+    fn test_apply_rewrites_line_and_inserts_import() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("a.rs");
+        fs::write(
+            &path,
+            "//! Module doc\n\nfn main() {\n    let x = std::fs::read_to_string(\"f\");\n}\n"
+        )
+        .unwrap();
+
+        let mut result = DiffResult::new();
+        let mut file = FileDiff::new(path.to_str().unwrap().to_string());
+        file.add_entry(entry(
+            4,
+            "    let x = std::fs::read_to_string(\"f\");",
+            "    let x = read_to_string(\"f\");",
+            Some("use std::fs::read_to_string;")
+        ));
+        result.add_file(file);
+
+        let applied = apply_diff(&result).unwrap();
+        assert_eq!(applied, 1);
+
+        let output = fs::read_to_string(&path).unwrap();
+        assert!(output.contains("use std::fs::read_to_string;"));
+        assert!(output.contains("let x = read_to_string(\"f\");"));
+        assert!(!output.contains("std::fs::read_to_string("));
+        assert!(output.starts_with("//! Module doc"));
+        assert!(output.ends_with('\n'));
+    }
+
+    #[test]
+    fn test_apply_skips_mismatched_original() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("b.rs");
+        fs::write(&path, "fn main() {\n    let x = 1;\n}\n").unwrap();
+
+        let mut result = DiffResult::new();
+        let mut file = FileDiff::new(path.to_str().unwrap().to_string());
+        file.add_entry(entry(2, "    let x = 2;", "    let x = changed;", None));
+        result.add_file(file);
+
+        let applied = apply_diff(&result).unwrap();
+        assert_eq!(applied, 0);
+
+        let output = fs::read_to_string(&path).unwrap();
+        assert!(output.contains("let x = 1;"));
+    }
+
+    #[test]
+    fn test_apply_dedups_imports() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("c.rs");
+        fs::write(
+            &path,
+            "fn main() {\n    let a = std::fs::read_to_string(\"a\");\n    let b = std::fs::read_to_string(\"b\");\n}\n"
+        )
+        .unwrap();
+
+        let mut result = DiffResult::new();
+        let mut file = FileDiff::new(path.to_str().unwrap().to_string());
+        file.add_entry(entry(
+            2,
+            "    let a = std::fs::read_to_string(\"a\");",
+            "    let a = read_to_string(\"a\");",
+            Some("use std::fs::read_to_string;")
+        ));
+        file.add_entry(entry(
+            3,
+            "    let b = std::fs::read_to_string(\"b\");",
+            "    let b = read_to_string(\"b\");",
+            Some("use std::fs::read_to_string;")
+        ));
+        result.add_file(file);
+
+        let applied = apply_diff(&result).unwrap();
+        assert_eq!(applied, 2);
+
+        let output = fs::read_to_string(&path).unwrap();
+        assert_eq!(output.matches("use std::fs::read_to_string;").count(), 1);
+    }
+
+    #[test]
+    fn test_apply_empty_result() {
+        let result = DiffResult::new();
+        let applied = apply_diff(&result).unwrap();
+        assert_eq!(applied, 0);
+    }
+}

--- a/src/differ/display.rs
+++ b/src/differ/display.rs
@@ -55,7 +55,7 @@ pub use self::{
     grid::{calculate_columns, render_grid},
     render::render_file_block
 };
-use super::types::{DiffEntry, DiffResult};
+use super::types::{DiffResult, FileDiff};
 use crate::error::IoError;
 
 /// Displays diff in summary mode with brief statistics.
@@ -239,7 +239,7 @@ pub fn show_full(result: &DiffResult, color: bool) {
 ///
 /// # Returns
 ///
-/// `AppResult<Vec<DiffEntry>>` - Selected entries for application, or error
+/// `AppResult<DiffResult>` - Selected entries grouped by file, or error
 ///
 /// # Errors
 ///
@@ -252,10 +252,10 @@ pub fn show_full(result: &DiffResult, color: bool) {
 ///
 /// let result = DiffResult::new();
 /// let selected = show_interactive(&result, false).unwrap();
-/// println!("Selected {} changes", selected.len());
+/// println!("Selected {} changes", selected.total_changes());
 /// ```
-pub fn show_interactive(result: &DiffResult, color: bool) -> AppResult<Vec<DiffEntry>> {
-    let mut selected = Vec::with_capacity(result.total_changes());
+pub fn show_interactive(result: &DiffResult, color: bool) -> AppResult<DiffResult> {
+    let mut selected = DiffResult::new();
     let mut apply_all = false;
 
     if color {
@@ -273,6 +273,8 @@ pub fn show_interactive(result: &DiffResult, color: bool) -> AppResult<Vec<DiffE
             println!("File: {}", file.path);
         }
         println!();
+
+        let mut file_selected = FileDiff::new(file.path.clone());
 
         for (idx, entry) in file.entries.iter().enumerate() {
             if color {
@@ -303,7 +305,7 @@ pub fn show_interactive(result: &DiffResult, color: bool) -> AppResult<Vec<DiffE
             println!();
 
             if apply_all {
-                selected.push(entry.clone());
+                file_selected.add_entry(entry.clone());
                 continue;
             }
 
@@ -315,7 +317,7 @@ pub fn show_interactive(result: &DiffResult, color: bool) -> AppResult<Vec<DiffE
 
             match input.trim().to_lowercase().as_str() {
                 "y" | "yes" => {
-                    selected.push(entry.clone());
+                    file_selected.add_entry(entry.clone());
                     println!("{}", "Applied".green());
                 }
                 "n" | "no" => {
@@ -323,12 +325,22 @@ pub fn show_interactive(result: &DiffResult, color: bool) -> AppResult<Vec<DiffE
                 }
                 "a" | "all" => {
                     apply_all = true;
-                    selected.push(entry.clone());
+                    file_selected.add_entry(entry.clone());
                     println!("{}", "Applying all remaining changes".green().bold());
                 }
                 "q" | "quit" => {
                     println!("{}", "Quit".red());
-                    break;
+                    selected.add_file(file_selected);
+                    println!(
+                        "\n{}",
+                        format!(
+                            "Selected {} changes for application",
+                            selected.total_changes()
+                        )
+                        .yellow()
+                        .bold()
+                    );
+                    return Ok(selected);
                 }
                 _ => {
                     println!("{}", "Invalid input, skipping".red());
@@ -336,13 +348,18 @@ pub fn show_interactive(result: &DiffResult, color: bool) -> AppResult<Vec<DiffE
             }
             println!();
         }
+
+        selected.add_file(file_selected);
     }
 
     println!(
         "\n{}",
-        format!("Selected {} changes for application", selected.len())
-            .yellow()
-            .bold()
+        format!(
+            "Selected {} changes for application",
+            selected.total_changes()
+        )
+        .yellow()
+        .bold()
     );
 
     Ok(selected)
@@ -351,7 +368,7 @@ pub fn show_interactive(result: &DiffResult, color: bool) -> AppResult<Vec<DiffE
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::differ::types::FileDiff;
+    use crate::differ::types::DiffEntry;
 
     #[test]
     fn test_show_summary_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ use crate::{
     analyzer::{AnalysisResult, Fix, Issue},
     analyzers::get_analyzers,
     cli::{Command, QualityArgs, Shell},
-    differ::{DiffResult, generate_diff, show_full, show_interactive, show_summary},
+    differ::{DiffResult, apply_diff, generate_diff, show_full, show_interactive, show_summary},
     error::{IoError, ParseError},
     file_utils::collect_rust_files,
     mod_rs::{ModRsResult, find_mod_rs_issues, fix_all_mod_rs},
@@ -663,7 +663,11 @@ fn run_diff(
     if summary {
         show_summary(&result, color);
     } else if interactive {
-        let _selected = show_interactive(&result, color)?;
+        let selected = show_interactive(&result, color)?;
+        if selected.total_changes() > 0 {
+            let applied = apply_diff(&selected)?;
+            println!("Applied {} changes", applied);
+        }
     } else {
         show_full(&result, color);
     }


### PR DESCRIPTION
## Summary

`diff --interactive` prompted per change but `run_diff` discarded the result (`let _selected = ...`), and `show_interactive` returned a flat `Vec<DiffEntry>` with no file association — so nothing was ever written.

## Changes

- `show_interactive` now returns a `DiffResult` with the accepted entries grouped by file (handles y/a; quit returns the accumulated selection).
- New `differ::apply::apply_diff`: replaces each recorded line by number, guarded by an equality check against the recorded original, and inserts deduplicated `use` imports after leading module docs / inner attributes so the file stays valid Rust.
- `run_diff` applies the selection and reports the applied count.

## Verification

```
$ printf 'y\n' | cargo qual diff --interactive sample.rs
Applied 1 changes
# std::fs::read_to_string("f") -> read_to_string("f"); use inserted after //! doc
```

Unit tests cover rewrite+import, mismatched-original skip, import dedup, and empty selection. `cargo test` (402), `cargo clippy --all-targets --all-features` — green.

Closes #75