### PR TITLE
#77 fix: safe path_import rewrites and ANSI-aware diff/report output

### DIFF
--- a/src/analyzers/path_import.rs
+++ b/src/analyzers/path_import.rs
@@ -10,7 +10,7 @@
 //! - Enum variants (should NOT be imported)
 //! - Associated constants (should NOT be imported)
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use masterror::AppResult;
 use syn::{
@@ -172,10 +172,23 @@ impl Analyzer for PathImportAnalyzer {
     }
 
     fn fix(&self, ast: &mut File) -> AppResult<usize> {
+        let mut collector = PathCollector {
+            paths: HashMap::new()
+        };
+        collector.visit_file(ast);
+
+        let blocked: HashSet<String> = collector
+            .paths
+            .into_iter()
+            .filter(|(_, sources)| sources.len() > 1)
+            .map(|(ident, _)| ident)
+            .collect();
+
         let mut fixer = PathFixer {
             fixed_count: 0,
-            imports:     Vec::new(),
-            seen:        HashSet::new()
+            imports: Vec::new(),
+            seen: HashSet::new(),
+            blocked
         };
         fixer.visit_file_mut(ast);
 
@@ -186,6 +199,48 @@ impl Analyzer for PathImportAnalyzer {
         }
 
         Ok(fixer.fixed_count)
+    }
+}
+
+/// Full colon-joined path string of an expression path.
+///
+/// # Arguments
+///
+/// * `path` - Path to render
+///
+/// # Returns
+///
+/// Segments joined with `::`
+fn path_to_string(path: &Path) -> String {
+    path.segments
+        .iter()
+        .map(|segment| segment.ident.to_string())
+        .collect::<Vec<_>>()
+        .join("::")
+}
+
+/// Collects the final identifier of each extractable path and its source paths.
+///
+/// Used to detect short-name collisions: an identifier reachable from more than
+/// one distinct full path cannot be safely rewritten to an import.
+struct PathCollector {
+    paths: HashMap<String, HashSet<String>>
+}
+
+impl<'ast> Visit<'ast> for PathCollector {
+    fn visit_expr_path(&mut self, node: &'ast ExprPath) {
+        if node.qself.is_none()
+            && PathImportAnalyzer::should_extract_to_import(&node.path)
+            && let Some(last) = node.path.segments.last()
+        {
+            let ident = last.ident.to_string();
+            self.paths
+                .entry(ident)
+                .or_default()
+                .insert(path_to_string(&node.path));
+        }
+
+        syn::visit::visit_expr_path(self, node);
     }
 }
 
@@ -243,21 +298,24 @@ impl<'ast> syn::visit::Visit<'ast> for PathVisitor {
 struct PathFixer {
     fixed_count: usize,
     imports:     Vec<Item>,
-    seen:        HashSet<String>
+    seen:        HashSet<String>,
+    blocked:     HashSet<String>
 }
 
 impl VisitMut for PathFixer {
     fn visit_expr_path_mut(&mut self, node: &mut ExprPath) {
         if node.qself.is_none() && PathImportAnalyzer::should_extract_to_import(&node.path) {
-            let path_str = node
+            let path_str = path_to_string(&node.path);
+
+            let is_blocked = node
                 .path
                 .segments
-                .iter()
-                .map(|s| s.ident.to_string())
-                .collect::<Vec<_>>()
-                .join("::");
+                .last()
+                .is_some_and(|last| self.blocked.contains(&last.ident.to_string()));
 
-            if let Some(last) = node.path.segments.last().cloned() {
+            if let Some(last) = node.path.segments.last().cloned()
+                && !is_blocked
+            {
                 if self.seen.insert(path_str.clone())
                     && let Ok(item_use) = syn::parse_str::<ItemUse>(&format!("use {};", path_str))
                 {
@@ -459,6 +517,43 @@ mod tests {
 
         let output = prettyplease::unparse(&code);
         assert_eq!(output.matches("use std::fs::read_to_string;").count(), 1);
+    }
+
+    #[test]
+    fn test_fix_skips_short_name_collision() {
+        let analyzer = PathImportAnalyzer::new();
+        let mut code: File = parse_quote! {
+            fn main() {
+                let a = std::fs::read("x");
+                let b = other::helpers::read("y");
+            }
+        };
+
+        let fixed = analyzer.fix(&mut code).unwrap();
+        assert_eq!(fixed, 0);
+
+        let output = prettyplease::unparse(&code);
+        assert!(output.contains("std::fs::read(\"x\")"));
+        assert!(output.contains("other::helpers::read(\"y\")"));
+        assert!(!output.contains("use std::fs::read;"));
+        assert!(!output.contains("use other::helpers::read;"));
+    }
+
+    #[test]
+    fn test_fix_same_path_repeated_is_not_collision() {
+        let analyzer = PathImportAnalyzer::new();
+        let mut code: File = parse_quote! {
+            fn main() {
+                let a = std::fs::read("x");
+                let b = std::fs::read("y");
+            }
+        };
+
+        let fixed = analyzer.fix(&mut code).unwrap();
+        assert_eq!(fixed, 2);
+
+        let output = prettyplease::unparse(&code);
+        assert_eq!(output.matches("use std::fs::read;").count(), 1);
     }
 
     #[test]

--- a/src/differ/display/grouping.rs
+++ b/src/differ/display/grouping.rs
@@ -96,34 +96,30 @@ pub fn group_imports(imports: &[&str]) -> Vec<String> {
 
             let common_prefix = find_common_prefix(&paths);
 
-            if !common_prefix.is_empty() {
-                let prefix_with_sep = if paths[0].starts_with(&format!("{}::", common_prefix)) {
-                    format!("{}::", common_prefix)
-                } else {
-                    common_prefix.clone()
-                };
+            if common_prefix.is_empty() {
+                result.push(format!("use {}::{{{}}};", root, paths.join(", ")));
+            } else {
+                let prefix_with_sep = format!("{}::", common_prefix);
 
                 let suffixes: Vec<String> = paths
                     .iter()
                     .map(|p| {
-                        p.strip_prefix(&prefix_with_sep)
-                            .unwrap_or(p.as_str())
-                            .to_string()
+                        if *p == common_prefix {
+                            "self".to_string()
+                        } else {
+                            p.strip_prefix(&prefix_with_sep)
+                                .unwrap_or(p.as_str())
+                                .to_string()
+                        }
                     })
                     .collect();
 
-                if prefix_with_sep.ends_with("::") {
-                    result.push(format!(
-                        "use {}::{}::{{{}}};",
-                        root,
-                        common_prefix,
-                        suffixes.join(", ")
-                    ));
-                } else {
-                    result.push(format!("use {}::{{{}}};", root, suffixes.join(", ")));
-                }
-            } else {
-                result.push(format!("use {}::{{{}}};", root, paths.join(", ")));
+                result.push(format!(
+                    "use {}::{}::{{{}}};",
+                    root,
+                    common_prefix,
+                    suffixes.join(", ")
+                ));
             }
         }
     }
@@ -289,6 +285,14 @@ mod tests {
         let result = group_imports(&imports);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], "use std::fs::write;");
+    }
+
+    #[test]
+    fn test_group_imports_bare_root_and_subpath() {
+        let imports = vec!["use std::fs;", "use std::fs::read;"];
+        let result = group_imports(&imports);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], "use std::fs::{self, read};");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -651,7 +651,12 @@ fn run_diff(
     let mut result = DiffResult::new();
 
     for file_path in files {
-        let file_diff = generate_diff(file_path.to_str().unwrap_or(""), &analyzers)?;
+        let Some(path_str) = file_path.to_str() else {
+            eprintln!("Skipping non-UTF-8 path: {}", file_path.display());
+            continue;
+        };
+
+        let file_diff = generate_diff(path_str, &analyzers)?;
         result.add_file(file_diff);
     }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -82,9 +82,12 @@ fn render_analyzer_block(
                 lines_str.join(", ")
             };
 
-            if joined.len() > 60 {
+            let plain_joined_len = lines_str.join(", ").len();
+
+            if plain_joined_len > 60 {
                 let mut line_chunks = Vec::new();
                 let mut current_line = String::new();
+                let mut current_len = 0;
 
                 for (i, line_num) in lines_str.iter().enumerate() {
                     let separator = if i == 0 { "" } else { ", " };
@@ -96,15 +99,17 @@ fn render_analyzer_block(
 
                     let addition_len = separator.len() + line_num.len();
 
-                    if current_line.len() + addition_len > 60 && !current_line.is_empty() {
+                    if current_len + addition_len > 60 && current_len > 0 {
                         line_chunks.push(current_line.clone());
                         current_line = if color {
                             format!("{}", line_num.magenta())
                         } else {
                             line_num.clone()
                         };
+                        current_len = line_num.len();
                     } else {
                         current_line.push_str(&addition);
+                        current_len += addition_len;
                     }
                 }
 


### PR DESCRIPTION
## Summary

Second-pass review fixes, bundled per request.

## Changes

1. **path_import fix — collision safety (correctness).** A two-pass fixer collects each extractable path's final identifier; identifiers reachable from more than one distinct path are left qualified and get no import, so `fix` never emits duplicate/ambiguous imports (previously turned compiling code into E0252/E0034). Verified end-to-end.
2. **report.rs — ANSI-aware wrapping (display).** Line-number list wrapping now uses visible length instead of byte length that included ANSI escapes in color mode.
3. **grouping.rs — bare-root grouping (display).** `use std::fs;` + `use std::fs::read;` now groups to `use std::fs::{self, read};` instead of invalid `use std::{, ::read};`.
4. **main.rs — non-UTF-8 paths (robustness).** `run_diff` skips non-UTF-8 paths with a warning instead of analyzing an empty path.

## Verification

- `cargo qual fix` on colliding `read` paths leaves both qualified (0 fixes); distinct names still rewrite.
- New tests for collision skip, repeated-path dedup, and bare-root grouping.
- `cargo test` (418), `cargo clippy --all-targets --all-features` — green.

Closes #77