### PR TITLE
#79 chore: release 0.3.0 and slim published crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cargo-quality"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-quality"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 authors = ["RAprogramm <andrey.rozanov.vl@gmail.com>"]
 description = "Professional Rust code quality analysis tool with hardcoded standards"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/cargo-quality"
 readme = "README.md"
 keywords = ["cargo", "quality", "formatter", "analyzer", "linter"]
 categories = ["development-tools", "command-line-utilities"]
-exclude = [".github", "target", ".git"]
+exclude = [".github", "target", ".git", "artifacts", "RELEASE_NOTES.md"]
 rust-version = "1.96"
 
 [dependencies]


### PR DESCRIPTION
## Summary

Release the accumulated fixes (unreleased since 0.2.0) and fix the published crate size.

## Changes

- Bump version 0.2.0 → 0.3.0 (minor: fix/format/interactive-diff went from no-op to functional).
- **Exclude CI `artifacts/` and `RELEASE_NOTES.md` from the package.** The `release` job downloads prebuilt binaries into `artifacts/` and then runs `cargo publish --allow-dirty` in the same workspace, so 0.1.5 and 0.2.0 shipped at ~9.6 MB. Excluding them keeps the crate at ~73 KB.

## Verification

- Published 0.2.0 inspected: 6 prebuilt binary archives under `artifacts/` (~9 MB).
- Simulated the CI workspace (9 MB `artifacts/` + `RELEASE_NOTES.md` present) → `cargo package` stays 73 KB, both excluded.

Merging to main triggers the tag `v0.3.0` + GitHub Release + crates.io publish.

Closes #79