### PR TITLE
#83 fix: use 'qual' subcommand in shell completions

### DIFF
--- a/install-completions.sh
+++ b/install-completions.sh
@@ -16,7 +16,7 @@ case "$SHELL_NAME" in
     bash)
         COMP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions"
         mkdir -p "$COMP_DIR"
-        cargo quality completions bash > "$COMP_DIR/cargo-quality"
+        cargo qual completions bash > "$COMP_DIR/cargo-quality"
         echo "✓ Bash completions installed to: $COMP_DIR/cargo-quality"
         echo "  Restart your shell or run: source $COMP_DIR/cargo-quality"
         ;;
@@ -24,30 +24,30 @@ case "$SHELL_NAME" in
         COMP_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/fish/completions"
         mkdir -p "$COMP_DIR"
 
-        # Generate cargo quality subcommand completions
+        # Generate cargo qual subcommand completions
         cat > "$COMP_DIR/cargo.fish" << 'EOF'
-# Completion for cargo quality subcommand
-complete -c cargo -n "__fish_seen_subcommand_from quality" -s h -l help -d 'Print help'
-complete -c cargo -n "__fish_seen_subcommand_from quality" -f -a "check" -d 'Check code quality'
-complete -c cargo -n "__fish_seen_subcommand_from quality" -f -a "fix" -d 'Fix quality issues'
-complete -c cargo -n "__fish_seen_subcommand_from quality" -f -a "format" -d 'Format code'
-complete -c cargo -n "__fish_seen_subcommand_from quality" -f -a "fmt" -d 'Run cargo +nightly fmt'
-complete -c cargo -n "__fish_seen_subcommand_from quality" -f -a "diff" -d 'Show proposed changes'
-complete -c cargo -n "__fish_seen_subcommand_from quality" -f -a "help" -d 'Display help'
-complete -c cargo -n "__fish_seen_subcommand_from quality" -f -a "completions" -d 'Generate completions'
+# Completion for cargo qual subcommand
+complete -c cargo -n "__fish_seen_subcommand_from qual" -s h -l help -d 'Print help'
+complete -c cargo -n "__fish_seen_subcommand_from qual" -f -a "check" -d 'Check code quality'
+complete -c cargo -n "__fish_seen_subcommand_from qual" -f -a "fix" -d 'Fix quality issues'
+complete -c cargo -n "__fish_seen_subcommand_from qual" -f -a "format" -d 'Format code'
+complete -c cargo -n "__fish_seen_subcommand_from qual" -f -a "fmt" -d 'Run cargo +nightly fmt'
+complete -c cargo -n "__fish_seen_subcommand_from qual" -f -a "diff" -d 'Show proposed changes'
+complete -c cargo -n "__fish_seen_subcommand_from qual" -f -a "help" -d 'Display help'
+complete -c cargo -n "__fish_seen_subcommand_from qual" -f -a "completions" -d 'Generate completions'
 
 # Diff options
-complete -c cargo -n "__fish_seen_subcommand_from quality; and __fish_seen_subcommand_from diff" -s s -l summary -d 'Brief summary'
-complete -c cargo -n "__fish_seen_subcommand_from quality; and __fish_seen_subcommand_from diff" -s i -l interactive -d 'Interactive mode'
+complete -c cargo -n "__fish_seen_subcommand_from qual; and __fish_seen_subcommand_from diff" -s s -l summary -d 'Brief summary'
+complete -c cargo -n "__fish_seen_subcommand_from qual; and __fish_seen_subcommand_from diff" -s i -l interactive -d 'Interactive mode'
 
 # Check options
-complete -c cargo -n "__fish_seen_subcommand_from quality; and __fish_seen_subcommand_from check" -s v -l verbose -d 'Detailed output'
+complete -c cargo -n "__fish_seen_subcommand_from qual; and __fish_seen_subcommand_from check" -s v -l verbose -d 'Detailed output'
 
 # Fix options
-complete -c cargo -n "__fish_seen_subcommand_from quality; and __fish_seen_subcommand_from fix" -s d -l dry-run -d 'Dry run'
+complete -c cargo -n "__fish_seen_subcommand_from qual; and __fish_seen_subcommand_from fix" -s d -l dry-run -d 'Dry run'
 
 # Completions options
-complete -c cargo -n "__fish_seen_subcommand_from quality; and __fish_seen_subcommand_from completions" -f -a "bash fish zsh powershell elvish"
+complete -c cargo -n "__fish_seen_subcommand_from qual; and __fish_seen_subcommand_from completions" -f -a "bash fish zsh powershell elvish"
 EOF
 
         echo "✓ Fish completions installed to: $COMP_DIR/cargo.fish"
@@ -56,7 +56,7 @@ EOF
     zsh)
         COMP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/zsh/site-functions"
         mkdir -p "$COMP_DIR"
-        cargo quality completions zsh > "$COMP_DIR/_cargo-quality"
+        cargo qual completions zsh > "$COMP_DIR/_cargo-quality"
         echo "✓ Zsh completions installed to: $COMP_DIR/_cargo-quality"
         echo "  Restart your shell or run: autoload -U compinit && compinit"
         ;;
@@ -64,7 +64,7 @@ EOF
         if command -v pwsh &> /dev/null; then
             PROFILE_DIR=$(pwsh -NoProfile -Command 'Split-Path $PROFILE')
             mkdir -p "$PROFILE_DIR"
-            cargo quality completions powershell > "$PROFILE_DIR/cargo-quality.ps1"
+            cargo qual completions powershell > "$PROFILE_DIR/cargo-quality.ps1"
             echo "✓ PowerShell completions installed to: $PROFILE_DIR/cargo-quality.ps1"
             echo "  Add this to your \$PROFILE:"
             echo "    . $PROFILE_DIR/cargo-quality.ps1"
@@ -76,7 +76,7 @@ EOF
     elvish)
         COMP_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/elvish/lib"
         mkdir -p "$COMP_DIR"
-        cargo quality completions elvish > "$COMP_DIR/cargo-quality.elv"
+        cargo qual completions elvish > "$COMP_DIR/cargo-quality.elv"
         echo "✓ Elvish completions installed to: $COMP_DIR/cargo-quality.elv"
         echo "  Add this to your rc.elv:"
         echo "    use cargo-quality"

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,28 +270,28 @@ fn get_completion_config(shell_name: &str) -> Option<(Shell, PathBuf, &'static s
 /// `AppResult<()>` - Ok if installation succeeds
 fn install_fish_completions(comp_file: &std::path::Path) -> AppResult<()> {
     let fish_completions = r#"# Completion for cargo qual subcommand
-complete -c cargo -n "__fish_seen_subcommand_from quality" -s h -l help -d 'Print help'
-complete -c cargo -n "__fish_seen_subcommand_from quality" -f -a "check" -d 'Check code quality'
-complete -c cargo -n "__fish_seen_subcommand_from quality" -f -a "fix" -d 'Fix quality issues'
-complete -c cargo -n "__fish_seen_subcommand_from quality" -f -a "format" -d 'Format code'
-complete -c cargo -n "__fish_seen_subcommand_from quality" -f -a "fmt" -d 'Run cargo +nightly fmt'
-complete -c cargo -n "__fish_seen_subcommand_from quality" -f -a "diff" -d 'Show proposed changes'
-complete -c cargo -n "__fish_seen_subcommand_from quality" -f -a "help" -d 'Display help'
-complete -c cargo -n "__fish_seen_subcommand_from quality" -f -a "completions" -d 'Generate completions'
-complete -c cargo -n "__fish_seen_subcommand_from quality" -f -a "setup" -d 'Setup completions'
+complete -c cargo -n "__fish_seen_subcommand_from qual" -s h -l help -d 'Print help'
+complete -c cargo -n "__fish_seen_subcommand_from qual" -f -a "check" -d 'Check code quality'
+complete -c cargo -n "__fish_seen_subcommand_from qual" -f -a "fix" -d 'Fix quality issues'
+complete -c cargo -n "__fish_seen_subcommand_from qual" -f -a "format" -d 'Format code'
+complete -c cargo -n "__fish_seen_subcommand_from qual" -f -a "fmt" -d 'Run cargo +nightly fmt'
+complete -c cargo -n "__fish_seen_subcommand_from qual" -f -a "diff" -d 'Show proposed changes'
+complete -c cargo -n "__fish_seen_subcommand_from qual" -f -a "help" -d 'Display help'
+complete -c cargo -n "__fish_seen_subcommand_from qual" -f -a "completions" -d 'Generate completions'
+complete -c cargo -n "__fish_seen_subcommand_from qual" -f -a "setup" -d 'Setup completions'
 
 # Diff options
-complete -c cargo -n "__fish_seen_subcommand_from quality; and __fish_seen_subcommand_from diff" -s s -l summary -d 'Brief summary'
-complete -c cargo -n "__fish_seen_subcommand_from quality; and __fish_seen_subcommand_from diff" -s i -l interactive -d 'Interactive mode'
+complete -c cargo -n "__fish_seen_subcommand_from qual; and __fish_seen_subcommand_from diff" -s s -l summary -d 'Brief summary'
+complete -c cargo -n "__fish_seen_subcommand_from qual; and __fish_seen_subcommand_from diff" -s i -l interactive -d 'Interactive mode'
 
 # Check options
-complete -c cargo -n "__fish_seen_subcommand_from quality; and __fish_seen_subcommand_from check" -s v -l verbose -d 'Detailed output'
+complete -c cargo -n "__fish_seen_subcommand_from qual; and __fish_seen_subcommand_from check" -s v -l verbose -d 'Detailed output'
 
 # Fix options
-complete -c cargo -n "__fish_seen_subcommand_from quality; and __fish_seen_subcommand_from fix" -s d -l dry-run -d 'Dry run'
+complete -c cargo -n "__fish_seen_subcommand_from qual; and __fish_seen_subcommand_from fix" -s d -l dry-run -d 'Dry run'
 
 # Completions options
-complete -c cargo -n "__fish_seen_subcommand_from quality; and __fish_seen_subcommand_from completions" -f -a "bash fish zsh powershell elvish"
+complete -c cargo -n "__fish_seen_subcommand_from qual; and __fish_seen_subcommand_from completions" -f -a "bash fish zsh powershell elvish"
 "#;
     fs::write(comp_file, fish_completions).map_err(IoError::from)?;
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -689,6 +689,18 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_install_fish_completions_uses_qual_subcommand() {
+        let temp_dir = TempDir::new().unwrap();
+        let comp_file = temp_dir.path().join("cargo.fish");
+
+        install_fish_completions(&comp_file).unwrap();
+
+        let content = fs::read_to_string(&comp_file).unwrap();
+        assert!(content.contains("__fish_seen_subcommand_from qual"));
+        assert!(!content.contains("__fish_seen_subcommand_from quality"));
+    }
+
+    #[test]
     fn test_check_quality() {
         let temp_dir = TempDir::new().unwrap();
         let file_path = temp_dir.path().join("test.rs");


### PR DESCRIPTION
## Summary

After the `cargo-quality` → `cargo-qual` rename, completion assets still referenced the old `quality` subcommand, so fish completions never fired and `install-completions.sh` failed for bash/zsh/powershell/elvish.

## Changes

- Fish guards `__fish_seen_subcommand_from quality` → `qual` (in `src/main.rs` and `install-completions.sh`).
- `cargo quality completions` → `cargo qual completions` in `install-completions.sh`.
- Updated stale comments.

## Verification

- `cargo qual completions <shell>` generates; fish guard token now `qual`.
- `bash -n install-completions.sh` OK.
- `cargo test` (418), `cargo clippy` — green.

Closes #83