### PR TITLE
#85 docs: auto-sync README overview from crate docs via cargo-rdme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,11 @@ jobs:
       - run: cargo doc --no-deps --all-features
         env:
           RUSTDOCFLAGS: -D warnings
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-rdme
+      - name: Check README is in sync with crate docs
+        run: cargo rdme --intralinks-strip-links --check
 
   # ============================================================================
   # STAGE 3: Benchmarks (after tests pass)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,116 @@ Professional Rust code quality analysis tool with hardcoded standards.
 
 ## Overview
 
-cargo-quality is a command-line tool that enforces consistent code quality standards across Rust projects without requiring local configuration files. All quality rules are hardcoded in the binary, ensuring uniform formatting and analysis across your entire codebase and organization.
+<!-- cargo-rdme start -->
+
+Professional Rust code quality analysis with hardcoded standards.
+
+`cargo-quality` is a zero-configuration code quality tool that enforces
+consistent standards across Rust projects. All rules are embedded in the
+binary, ensuring uniform analysis across your entire codebase.
+
+### Modules
+
+This library provides:
+
+- **`analyzer`** - Core trait and types for building analyzers
+- **`analyzers`** - Built-in analyzers for common code quality issues
+- **`formatter`** - Code formatting with hardcoded standards
+- **`differ`** - Diff generation and visualization
+- **`report`** - Analysis report generation
+- **`error`** - Error types for quality operations
+
+### Quick Start
+
+Analyze code for path imports that should be extracted:
+
+```rust
+use cargo_quality::{analyzer::Analyzer, analyzers::PathImportAnalyzer};
+
+let analyzer = PathImportAnalyzer::new();
+let code = r#"
+    fn main() {
+        let content = std::fs::read_to_string("file.txt");
+    }
+"#;
+let ast = syn::parse_file(code).unwrap();
+let result = analyzer.analyze(&ast, code).unwrap();
+
+assert!(!result.issues.is_empty());
+assert!(result.issues[0].message.contains("Use import"));
+```
+
+### Available Analyzers
+
+| Analyzer | Description |
+|----------|-------------|
+| `PathImportAnalyzer` | Detects `std::fs::read` paths that should use `use` |
+| `FormatArgsAnalyzer` | Finds `println!("{}", x)` that should use `{x}` |
+| `EmptyLinesAnalyzer` | Finds empty lines in function bodies |
+| `InlineCommentsAnalyzer` | Finds `//` comments that should be `///` |
+
+
+### Running All Analyzers
+
+Use `analyzers::get_analyzers()` to get all built-in analyzers:
+
+```rust
+use cargo_quality::{analyzer::Analyzer, analyzers::get_analyzers};
+
+let code = r#"
+    fn main() {
+        let x = std::fs::read("file");
+    }
+"#;
+let ast = syn::parse_file(code).unwrap();
+
+for analyzer in get_analyzers() {
+    let result = analyzer.analyze(&ast, code).unwrap();
+    println!("[{}] {} issues", analyzer.name(), result.issues.len());
+}
+```
+
+### Custom Analyzers
+
+Implement the `analyzer::Analyzer` trait to create custom analyzers:
+
+```rust
+use cargo_quality::analyzer::{AnalysisResult, Analyzer};
+use masterror::AppResult;
+use syn::File;
+
+struct MyAnalyzer;
+
+impl Analyzer for MyAnalyzer {
+    fn name(&self) -> &'static str {
+        "my_analyzer"
+    }
+
+    fn analyze(&self, _ast: &File, _content: &str) -> AppResult<AnalysisResult> {
+        Ok(AnalysisResult::default())
+    }
+
+    fn fix(&self, _ast: &mut File) -> AppResult<usize> {
+        Ok(0)
+    }
+}
+```
+
+### Feature Flags
+
+This crate has no optional features. All functionality is enabled by
+default.
+
+### Standards
+
+This tool enforces standards from [RustManifest](https://github.com/RAprogramm/RustManifest):
+
+- No inline `::` paths in code (use `use` statements)
+- Named format arguments for readability
+- No empty lines inside function bodies
+- Doc comments only (no inline `//` comments)
+
+<!-- cargo-rdme end -->
 
 <img width="1483" height="907" alt="image" src="https://github.com/user-attachments/assets/74a2449e-7231-468d-a660-28d2fedd1c5d" />
 
@@ -717,6 +826,14 @@ Check license compliance:
 
 ```bash
 reuse lint
+```
+
+The Overview section of this README is generated from the crate-level docs in
+`src/lib.rs` with [`cargo-rdme`](https://github.com/orium/cargo-rdme). After
+changing those docs, regenerate it (CI verifies it stays in sync):
+
+```bash
+cargo rdme --intralinks-strip-links
 ```
 
 <div align="right"><a href="#table-of-contents">Back to top</a></div>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! consistent standards across Rust projects. All rules are embedded in the
 //! binary, ensuring uniform analysis across your entire codebase.
 //!
-//! # Overview
+//! # Modules
 //!
 //! This library provides:
 //!


### PR DESCRIPTION
## Summary

Keep the hand-written README but generate its Overview from the crate-level docs, so they never drift.

## Changes

- Wrap the README Overview in `<!-- cargo-rdme start/end -->` markers, generated from `src/lib.rs` `//!` docs (intralinks stripped for GitHub markdown).
- Rename the crate-doc `# Overview` heading to `# Modules` to avoid an "Overview under Overview" nesting in the README.
- CI: install `cargo-rdme` and run `cargo rdme --intralinks-strip-links --check` in the Documentation job, so a stale README fails CI. (`RUSTDOCFLAGS=-D warnings` was already enforced there.)
- Document the regeneration command in the README Development section.

## Verification

- `cargo rdme --check` exits 0; `cargo doc --no-deps --all-features` with `-D warnings` clean.
- `cargo test` (419), `cargo clippy` — green.

Hand-written sections (Commands, GitHub Action, examples) are untouched.

Closes #85