### PR TITLE
#89 fix: line analyzers false-positive inside string literals

### DIFF
--- a/src/analyzers.rs
+++ b/src/analyzers.rs
@@ -120,12 +120,58 @@ pub mod format_args;
 pub mod inline_comments;
 pub mod path_import;
 
+use std::collections::HashSet;
+
 pub use empty_lines::EmptyLinesAnalyzer;
 pub use format_args::FormatArgsAnalyzer;
 pub use inline_comments::InlineCommentsAnalyzer;
 pub use path_import::PathImportAnalyzer;
+use syn::{File, Lit, visit::Visit};
 
 use crate::analyzer::Analyzer;
+
+/// Collects line numbers that lie inside multi-line literals.
+///
+/// Line-based analyzers scan raw source text, so a `//` or a blank line inside
+/// a multi-line string literal would otherwise be mistaken for a comment or an
+/// empty function line. This returns every continuation line of such literals
+/// (the lines after the opening one, up to and including the closing one) so
+/// callers can skip them.
+///
+/// # Arguments
+///
+/// * `ast` - Parsed file to scan for literals
+///
+/// # Returns
+///
+/// Set of 1-based line numbers that fall inside a multi-line literal
+pub(crate) fn multiline_literal_lines(ast: &File) -> HashSet<usize> {
+    struct LitVisitor {
+        lines: HashSet<usize>
+    }
+
+    impl<'ast> Visit<'ast> for LitVisitor {
+        fn visit_lit(&mut self, lit: &'ast Lit) {
+            let span = lit.span();
+            let start = span.start().line;
+            let end = span.end().line;
+
+            if end > start {
+                for line in (start + 1)..=end {
+                    self.lines.insert(line);
+                }
+            }
+
+            syn::visit::visit_lit(self, lit);
+        }
+    }
+
+    let mut visitor = LitVisitor {
+        lines: HashSet::new()
+    };
+    visitor.visit_file(ast);
+    visitor.lines
+}
 
 /// Returns all built-in analyzers.
 ///

--- a/src/analyzers/empty_lines.rs
+++ b/src/analyzers/empty_lines.rs
@@ -7,6 +7,8 @@
 //! which violate the Single Responsibility Principle by suggesting the
 //! function does multiple things.
 
+use std::collections::HashSet;
+
 use masterror::AppResult;
 use syn::{File, ImplItem, Item, ItemFn, ItemImpl, spanned::Spanned, visit::Visit};
 
@@ -50,7 +52,12 @@ impl EmptyLinesAnalyzer {
     /// # Returns
     ///
     /// Vector of issues found
-    fn check_block(start_line: usize, end_line: usize, lines: &[&str]) -> Vec<Issue> {
+    fn check_block(
+        start_line: usize,
+        end_line: usize,
+        lines: &[&str],
+        excluded: &HashSet<usize>
+    ) -> Vec<Issue> {
         let mut issues = Vec::new();
 
         if start_line >= end_line {
@@ -58,6 +65,10 @@ impl EmptyLinesAnalyzer {
         }
 
         for line_num in start_line..end_line {
+            if excluded.contains(&line_num) {
+                continue;
+            }
+
             let idx = line_num.saturating_sub(1);
 
             let Some(line) = lines.get(idx) else {
@@ -145,12 +156,12 @@ impl EmptyLinesAnalyzer {
     ///
     /// * `func` - Function item to analyze
     /// * `lines` - Source code split into lines
-    fn check_function(func: &ItemFn, lines: &[&str]) -> Vec<Issue> {
+    fn check_function(func: &ItemFn, lines: &[&str], excluded: &HashSet<usize>) -> Vec<Issue> {
         let span = func.block.span();
         let start_line = span.start().line;
         let end_line = span.end().line;
 
-        Self::check_block(start_line, end_line, lines)
+        Self::check_block(start_line, end_line, lines, excluded)
     }
 
     /// Check impl block methods for empty lines.
@@ -159,7 +170,11 @@ impl EmptyLinesAnalyzer {
     ///
     /// * `impl_block` - Impl block to analyze
     /// * `lines` - Source code split into lines
-    fn check_impl_block(impl_block: &ItemImpl, lines: &[&str]) -> Vec<Issue> {
+    fn check_impl_block(
+        impl_block: &ItemImpl,
+        lines: &[&str],
+        excluded: &HashSet<usize>
+    ) -> Vec<Issue> {
         let mut issues = Vec::new();
 
         for item in &impl_block.items {
@@ -168,7 +183,7 @@ impl EmptyLinesAnalyzer {
                 let start_line = span.start().line;
                 let end_line = span.end().line;
 
-                issues.extend(Self::check_block(start_line, end_line, lines));
+                issues.extend(Self::check_block(start_line, end_line, lines, excluded));
             }
         }
 
@@ -183,9 +198,11 @@ impl Analyzer for EmptyLinesAnalyzer {
 
     fn analyze(&self, ast: &File, content: &str) -> AppResult<AnalysisResult> {
         let lines: Vec<&str> = content.lines().collect();
+        let excluded = crate::analyzers::multiline_literal_lines(ast);
         let mut visitor = FunctionVisitor {
-            issues: Vec::new(),
-            lines:  &lines
+            issues:   Vec::new(),
+            lines:    &lines,
+            excluded: &excluded
         };
         visitor.visit_file(ast);
 
@@ -201,19 +218,22 @@ impl Analyzer for EmptyLinesAnalyzer {
 }
 
 struct FunctionVisitor<'a> {
-    issues: Vec<Issue>,
-    lines:  &'a [&'a str]
+    issues:   Vec<Issue>,
+    lines:    &'a [&'a str],
+    excluded: &'a HashSet<usize>
 }
 
 impl<'ast, 'a> Visit<'ast> for FunctionVisitor<'a> {
     fn visit_item(&mut self, node: &'ast Item) {
         match node {
             Item::Fn(func) => {
-                let func_issues = EmptyLinesAnalyzer::check_function(func, self.lines);
+                let func_issues =
+                    EmptyLinesAnalyzer::check_function(func, self.lines, self.excluded);
                 self.issues.extend(func_issues);
             }
             Item::Impl(impl_block) => {
-                let impl_issues = EmptyLinesAnalyzer::check_impl_block(impl_block, self.lines);
+                let impl_issues =
+                    EmptyLinesAnalyzer::check_impl_block(impl_block, self.lines, self.excluded);
                 self.issues.extend(impl_issues);
             }
             _ => {}
@@ -236,6 +256,16 @@ mod tests {
     fn test_analyzer_name() {
         let analyzer = EmptyLinesAnalyzer::new();
         assert_eq!(analyzer.name(), "empty_lines");
+    }
+
+    #[test]
+    fn test_ignore_blank_line_inside_string_literal() {
+        let analyzer = EmptyLinesAnalyzer::new();
+        let content = "fn f() {\n    let s = \"line one\n\nline two\";\n    let _ = s;\n}";
+        let code = syn::parse_str(content).unwrap();
+
+        let result = analyzer.analyze(&code, content).unwrap();
+        assert_eq!(result.issues.len(), 0);
     }
 
     #[test]

--- a/src/analyzers/inline_comments.rs
+++ b/src/analyzers/inline_comments.rs
@@ -7,6 +7,8 @@
 //! bodies, which violate the documentation standards. All explanations should
 //! be in doc comments (`///`), specifically in the `# Notes` section.
 
+use std::collections::HashSet;
+
 use masterror::AppResult;
 use syn::{File, ImplItem, Item, ItemFn, ItemImpl, spanned::Spanned, visit::Visit};
 
@@ -63,7 +65,12 @@ impl InlineCommentsAnalyzer {
     /// # Returns
     ///
     /// Vector of issues found
-    fn check_block(start_line: usize, end_line: usize, lines: &[&str]) -> Vec<Issue> {
+    fn check_block(
+        start_line: usize,
+        end_line: usize,
+        lines: &[&str],
+        excluded: &HashSet<usize>
+    ) -> Vec<Issue> {
         let mut issues = Vec::new();
 
         if start_line >= end_line {
@@ -71,6 +78,10 @@ impl InlineCommentsAnalyzer {
         }
 
         for line_num in start_line..end_line {
+            if excluded.contains(&line_num) {
+                continue;
+            }
+
             let idx = line_num.saturating_sub(1);
 
             let Some(line) = lines.get(idx) else {
@@ -143,12 +154,12 @@ impl InlineCommentsAnalyzer {
     ///
     /// * `func` - Function item to analyze
     /// * `lines` - Source code split into lines
-    fn check_function(func: &ItemFn, lines: &[&str]) -> Vec<Issue> {
+    fn check_function(func: &ItemFn, lines: &[&str], excluded: &HashSet<usize>) -> Vec<Issue> {
         let span = func.block.span();
         let start_line = span.start().line;
         let end_line = span.end().line;
 
-        Self::check_block(start_line, end_line, lines)
+        Self::check_block(start_line, end_line, lines, excluded)
     }
 
     /// Check impl block methods for inline comments.
@@ -157,7 +168,11 @@ impl InlineCommentsAnalyzer {
     ///
     /// * `impl_block` - Impl block to analyze
     /// * `lines` - Source code split into lines
-    fn check_impl_block(impl_block: &ItemImpl, lines: &[&str]) -> Vec<Issue> {
+    fn check_impl_block(
+        impl_block: &ItemImpl,
+        lines: &[&str],
+        excluded: &HashSet<usize>
+    ) -> Vec<Issue> {
         let mut issues = Vec::new();
 
         for item in &impl_block.items {
@@ -166,7 +181,7 @@ impl InlineCommentsAnalyzer {
                 let start_line = span.start().line;
                 let end_line = span.end().line;
 
-                issues.extend(Self::check_block(start_line, end_line, lines));
+                issues.extend(Self::check_block(start_line, end_line, lines, excluded));
             }
         }
 
@@ -181,9 +196,11 @@ impl Analyzer for InlineCommentsAnalyzer {
 
     fn analyze(&self, ast: &File, content: &str) -> AppResult<AnalysisResult> {
         let lines: Vec<&str> = content.lines().collect();
+        let excluded = crate::analyzers::multiline_literal_lines(ast);
         let mut visitor = FunctionVisitor {
-            issues: Vec::new(),
-            lines:  &lines
+            issues:   Vec::new(),
+            lines:    &lines,
+            excluded: &excluded
         };
         visitor.visit_file(ast);
 
@@ -199,19 +216,25 @@ impl Analyzer for InlineCommentsAnalyzer {
 }
 
 struct FunctionVisitor<'a> {
-    issues: Vec<Issue>,
-    lines:  &'a [&'a str]
+    issues:   Vec<Issue>,
+    lines:    &'a [&'a str],
+    excluded: &'a HashSet<usize>
 }
 
 impl<'ast, 'a> Visit<'ast> for FunctionVisitor<'a> {
     fn visit_item(&mut self, node: &'ast Item) {
         match node {
             Item::Fn(func) => {
-                let func_issues = InlineCommentsAnalyzer::check_function(func, self.lines);
+                let func_issues =
+                    InlineCommentsAnalyzer::check_function(func, self.lines, self.excluded);
                 self.issues.extend(func_issues);
             }
             Item::Impl(impl_block) => {
-                let impl_issues = InlineCommentsAnalyzer::check_impl_block(impl_block, self.lines);
+                let impl_issues = InlineCommentsAnalyzer::check_impl_block(
+                    impl_block,
+                    self.lines,
+                    self.excluded
+                );
                 self.issues.extend(impl_issues);
             }
             _ => {}
@@ -234,6 +257,17 @@ mod tests {
     fn test_analyzer_name() {
         let analyzer = InlineCommentsAnalyzer::new();
         assert_eq!(analyzer.name(), "inline_comments");
+    }
+
+    #[test]
+    fn test_ignore_double_slash_inside_string_literal() {
+        let analyzer = InlineCommentsAnalyzer::new();
+        let content =
+            "fn f() {\n    let s = \"first\n// not a comment\nlast\";\n    let _ = s;\n}";
+        let code = syn::parse_str(content).unwrap();
+
+        let result = analyzer.analyze(&code, content).unwrap();
+        assert_eq!(result.issues.len(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`EmptyLinesAnalyzer` and `InlineCommentsAnalyzer` scanned raw text lines, so a blank line or a `//` line inside a multi-line string literal (embedded SQL/HTML/help text) was wrongly flagged.

## Changes

- Add `analyzers::multiline_literal_lines(ast)`: collects the continuation line numbers of multi-line literals from the AST (`proc_macro2` span-locations).
- Both analyzers skip those lines in `check_block`.

## Verification

Before: a function with a multi-line string containing a blank line and a `//` line reported 1 `empty_lines` + 1 `inline_comments` issue. After: 0.

Regression tests added in both analyzers. `cargo test` (429), `cargo clippy --all-targets --all-features`, nightly `fmt --check` — green.

Closes #89