### PR TITLE
#91 fix: check exits non-zero when issues are found

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,6 +779,10 @@ jobs:
         run: cargo qual fmt
 ```
 
+`cargo qual check` exits with code `1` when any issues are found and `0`
+otherwise, so the step above fails the job on quality issues without extra
+scripting.
+
 <div align="right"><a href="#table-of-contents">Back to top</a></div>
 
 ## Benefits

--- a/src/help.rs
+++ b/src/help.rs
@@ -42,6 +42,11 @@ pub fn display_help() {
     );
     println!(
         "    {} {}",
+        "EXIT:".fg::<Blue>().dimmed(),
+        "1 if any issues are found, 0 otherwise (usable as a CI gate)".fg::<Magenta>()
+    );
+    println!(
+        "    {} {}",
         "OPTIONS:".fg::<Blue>().dimmed(),
         "--verbose, -v | --analyzer, -a <NAME> | --color, -c".fg::<Magenta>()
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,12 +56,7 @@ fn main() -> AppResult<()> {
             verbose,
             analyzer,
             color
-        } => {
-            let has_issues = check_quality(&path, verbose, analyzer.as_deref(), color)?;
-            if has_issues {
-                std::process::exit(1);
-            }
-        }
+        } => std::process::exit(check_command(&path, verbose, analyzer.as_deref(), color)?),
         Command::Fix {
             path,
             dry_run,
@@ -462,6 +457,29 @@ fn check_quality(
     Ok(global_report.total_issues() > 0)
 }
 
+/// Runs the check command and maps the result to a process exit code.
+///
+/// # Arguments
+///
+/// * `path` - File or directory path to analyze
+/// * `verbose` - Print confirmation for files without issues
+/// * `analyzer_name` - Optional analyzer name to run
+/// * `color` - Enable colored output
+///
+/// # Returns
+///
+/// `AppResult<i32>` - `1` if any issues were found, `0` otherwise, error on IO
+/// or parse failures
+fn check_command(
+    path: &str,
+    verbose: bool,
+    analyzer_name: Option<&str>,
+    color: bool
+) -> AppResult<i32> {
+    let has_issues = check_quality(path, verbose, analyzer_name, color)?;
+    Ok(i32::from(has_issues))
+}
+
 /// Adds mod.rs issues to the global report.
 ///
 /// Converts ModRsResult into Report format for unified display.
@@ -719,6 +737,28 @@ mod tests {
 
         let result = check_quality(temp_dir.path().to_str().unwrap(), false, None, false);
         assert!(result.unwrap(), "issues present should return true");
+    }
+
+    #[test]
+    fn test_check_command_exit_codes() {
+        let temp_dir = TempDir::new().unwrap();
+        let dirty = temp_dir.path().join("dirty.rs");
+        fs::write(
+            &dirty,
+            "fn main() { let x = std::fs::read_to_string(\"f\"); }"
+        )
+        .unwrap();
+        assert_eq!(
+            check_command(dirty.to_str().unwrap(), false, None, false).unwrap(),
+            1
+        );
+
+        let clean = temp_dir.path().join("clean.rs");
+        fs::write(&clean, "fn main() {}").unwrap();
+        assert_eq!(
+            check_command(clean.to_str().unwrap(), false, None, false).unwrap(),
+            0
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,12 @@ fn main() -> AppResult<()> {
             verbose,
             analyzer,
             color
-        } => check_quality(&path, verbose, analyzer.as_deref(), color)?,
+        } => {
+            let has_issues = check_quality(&path, verbose, analyzer.as_deref(), color)?;
+            if has_issues {
+                std::process::exit(1);
+            }
+        }
         Command::Fix {
             path,
             dry_run,
@@ -373,7 +378,9 @@ fn run_mod_rs(path: &str, fix: bool) -> AppResult<()> {
 ///
 /// # Returns
 ///
-/// `AppResult<()>` - Ok if analysis completes, error on IO or parse failures
+/// `AppResult<bool>` - `Ok(true)` if any issues were found, `Ok(false)` if the
+/// code is clean, error on IO or parse failures. The caller maps `true` to a
+/// non-zero process exit code so `check` can gate CI.
 ///
 /// # Examples
 ///
@@ -387,7 +394,7 @@ fn check_quality(
     verbose: bool,
     analyzer_name: Option<&str>,
     color: bool
-) -> AppResult<()> {
+) -> AppResult<bool> {
     let files = collect_rust_files(path)?;
     let all_analyzers = get_analyzers();
 
@@ -409,7 +416,7 @@ fn check_quality(
             eprintln!("  - {}", analyzer.name());
         }
         eprintln!("  - mod_rs");
-        return Ok(());
+        return Ok(false);
     }
 
     let mut global_report = GlobalReport::new();
@@ -452,7 +459,7 @@ fn check_quality(
         print!("{}", global_report.display_compact(color));
     }
 
-    Ok(())
+    Ok(global_report.total_issues() > 0)
 }
 
 /// Adds mod.rs issues to the global report.
@@ -711,7 +718,7 @@ mod tests {
         .unwrap();
 
         let result = check_quality(temp_dir.path().to_str().unwrap(), false, None, false);
-        assert!(result.is_ok());
+        assert!(result.unwrap(), "issues present should return true");
     }
 
     #[test]
@@ -782,7 +789,7 @@ mod tests {
     fn test_check_quality_no_files() {
         let temp_dir = TempDir::new().unwrap();
         let result = check_quality(temp_dir.path().to_str().unwrap(), false, None, false);
-        assert!(result.is_ok());
+        assert!(!result.unwrap(), "no files means no issues");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`cargo qual check` always exited 0, so the documented "CI/CD Integration (Manual)" gate step (`run: cargo qual check`) could never fail. Now it exits `1` when issues are found, matching standard linters.

## Changes

- `check_quality` returns `AppResult<bool>` (issues found); `main` maps `true` to `process::exit(1)`. Unit tests call `check_quality` directly, so they are unaffected by the exit.
- `fix`/`format`/`diff` exit codes unchanged.
- Documented the exit-code contract in `help` output and the README CI/CD section.

## Verification

- Dirty tree → exit `1`; clean tree → exit `0`.
- Tests assert `Ok(true)` on issues and `Ok(false)` on a clean/empty tree.
- `cargo test` (429), `cargo clippy --all-targets --all-features`, nightly `fmt --check`, `cargo rdme --check` — green.

Closes #91