### PR TITLE
#93 fix: apply fixes as byte-range edits to preserve comments and formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,6 @@ dependencies = [
  "ignore",
  "masterror",
  "owo-colors",
- "prettyplease",
  "proc-macro2",
  "quote",
  "syn",
@@ -655,16 +654,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ quote = "1"
 proc-macro2 = { version = "1", features = ["span-locations"] }
 masterror = "0.29"
 ignore = "0.4"
-prettyplease = "0.2"
 owo-colors = "4"
 terminal_size = "0.4"
 unicode-width = "0.2"

--- a/README.md
+++ b/README.md
@@ -128,10 +128,6 @@ impl Analyzer for MyAnalyzer {
     fn analyze(&self, _ast: &File, _content: &str) -> AppResult<AnalysisResult> {
         Ok(AnalysisResult::default())
     }
-
-    fn fix(&self, _ast: &mut File) -> AppResult<usize> {
-        Ok(0)
-    }
 }
 ```
 

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -9,8 +9,37 @@
 //! - `Issue` struct representing detected problems
 //! - `AnalysisResult` struct containing analysis outcomes
 
+use std::ops::Range;
+
 use masterror::AppResult;
 use syn::File;
+
+/// A single text replacement over the original source.
+///
+/// Fixes are expressed as byte-range edits against the untouched source text so
+/// that everything outside the edited range — comments, blank lines, and the
+/// author's formatting — is preserved. This mirrors how `rustfmt` and
+/// `rust-analyzer` apply changes, rather than reprinting the AST (which loses
+/// comments and reformats the whole file).
+///
+/// # Examples
+///
+/// ```
+/// use cargo_quality::analyzer::TextEdit;
+///
+/// let edit = TextEdit {
+///     range:       0..9,
+///     replacement: String::new()
+/// };
+/// assert_eq!(edit.range.len(), 9);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TextEdit {
+    /// Byte range in the original source to replace
+    pub range:       Range<usize>,
+    /// Text to substitute for the range (empty to delete)
+    pub replacement: String
+}
 
 /// Type of fix that can be applied to resolve an issue.
 ///
@@ -183,10 +212,6 @@ pub struct AnalysisResult {
 ///     fn analyze(&self, ast: &File, content: &str) -> AppResult<AnalysisResult> {
 ///         Ok(AnalysisResult::default())
 ///     }
-///
-///     fn fix(&self, ast: &mut File) -> AppResult<usize> {
-///         Ok(0)
-///     }
 /// }
 /// ```
 pub trait Analyzer {
@@ -207,18 +232,24 @@ pub trait Analyzer {
     /// `AppResult<AnalysisResult>` - Analysis results or error
     fn analyze(&self, ast: &File, content: &str) -> AppResult<AnalysisResult>;
 
-    /// Apply automatic fixes to syntax tree.
+    /// Produce byte-range text edits that fix the detected issues.
     ///
-    /// Modifies the AST in-place to fix detected issues.
+    /// Edits are applied against the original source, preserving everything
+    /// outside the edited ranges (comments, blank lines, formatting). The
+    /// default implementation returns no edits, for analyzers that are advisory
+    /// only.
     ///
     /// # Arguments
     ///
-    /// * `ast` - Mutable syntax tree to fix
+    /// * `ast` - Parsed Rust syntax tree to fix
+    /// * `content` - Original source code the edits apply to
     ///
     /// # Returns
     ///
-    /// `AppResult<usize>` - Number of fixes applied or error
-    fn fix(&self, ast: &mut File) -> AppResult<usize>;
+    /// `AppResult<Vec<TextEdit>>` - Non-overlapping edits, or error
+    fn edits(&self, _ast: &File, _content: &str) -> AppResult<Vec<TextEdit>> {
+        Ok(Vec::new())
+    }
 }
 
 #[cfg(test)]

--- a/src/analyzers/empty_lines.rs
+++ b/src/analyzers/empty_lines.rs
@@ -211,10 +211,6 @@ impl Analyzer for EmptyLinesAnalyzer {
             fixable_count: 0
         })
     }
-
-    fn fix(&self, _ast: &mut File) -> AppResult<usize> {
-        Ok(0)
-    }
 }
 
 struct FunctionVisitor<'a> {
@@ -374,17 +370,17 @@ mod tests {
     }
 
     #[test]
-    fn test_fix_returns_zero() {
+    fn test_no_edits() {
         let analyzer = EmptyLinesAnalyzer::new();
         let content = r#"fn main() {
     let x = 1;
 
     let y = 2;
 }"#;
-        let mut code = syn::parse_str(content).unwrap();
+        let code = syn::parse_str(content).unwrap();
 
-        let fixed = analyzer.fix(&mut code).unwrap();
-        assert_eq!(fixed, 0);
+        let edits = analyzer.edits(&code, content).unwrap();
+        assert!(edits.is_empty());
     }
 
     #[test]

--- a/src/analyzers/format_args.rs
+++ b/src/analyzers/format_args.rs
@@ -139,10 +139,6 @@ impl Analyzer for FormatArgsAnalyzer {
             fixable_count: 0
         })
     }
-
-    fn fix(&self, _ast: &mut File) -> AppResult<usize> {
-        Ok(0)
-    }
 }
 
 struct FormatVisitor {
@@ -308,16 +304,16 @@ mod tests {
     }
 
     #[test]
-    fn test_fix_returns_zero() {
+    fn test_no_edits() {
         let analyzer = FormatArgsAnalyzer::new();
-        let mut code: File = parse_quote! {
+        let code: File = parse_quote! {
             fn main() {
                 println!("Hello {} {} {}", 1, 2, 3);
             }
         };
 
-        let fixed = analyzer.fix(&mut code).unwrap();
-        assert_eq!(fixed, 0);
+        let edits = analyzer.edits(&code, "").unwrap();
+        assert!(edits.is_empty());
     }
 
     #[test]

--- a/src/analyzers/inline_comments.rs
+++ b/src/analyzers/inline_comments.rs
@@ -209,10 +209,6 @@ impl Analyzer for InlineCommentsAnalyzer {
             fixable_count: 0
         })
     }
-
-    fn fix(&self, _ast: &mut File) -> AppResult<usize> {
-        Ok(0)
-    }
 }
 
 struct FunctionVisitor<'a> {
@@ -398,16 +394,16 @@ impl Foo {
     }
 
     #[test]
-    fn test_fix_returns_zero() {
+    fn test_no_edits() {
         let analyzer = InlineCommentsAnalyzer::new();
         let content = r#"fn main() {
     // Comment
     let x = 1;
 }"#;
-        let mut code = syn::parse_str(content).unwrap();
+        let code = syn::parse_str(content).unwrap();
 
-        let fixed = analyzer.fix(&mut code).unwrap();
-        assert_eq!(fixed, 0);
+        let edits = analyzer.edits(&code, content).unwrap();
+        assert!(edits.is_empty());
     }
 
     #[test]

--- a/src/analyzers/path_import.rs
+++ b/src/analyzers/path_import.rs
@@ -13,15 +13,12 @@
 use std::collections::{HashMap, HashSet};
 
 use masterror::AppResult;
-use syn::{
-    ExprPath, File, Item, ItemUse, Path,
-    punctuated::Punctuated,
-    spanned::Spanned,
-    visit::Visit,
-    visit_mut::{self, VisitMut}
-};
+use syn::{ExprPath, File, Path, spanned::Spanned, visit::Visit};
 
-use crate::analyzer::{AnalysisResult, Analyzer, Fix, Issue};
+use crate::{
+    analyzer::{AnalysisResult, Analyzer, Fix, Issue, TextEdit},
+    fixer::import_insertion_offset
+};
 
 /// Analyzer for detecting path separators that should be imports.
 ///
@@ -171,34 +168,57 @@ impl Analyzer for PathImportAnalyzer {
         })
     }
 
-    fn fix(&self, ast: &mut File) -> AppResult<usize> {
+    fn edits(&self, ast: &File, content: &str) -> AppResult<Vec<TextEdit>> {
+        let blocked = Self::colliding_idents(ast);
+
+        let mut visitor = EditVisitor {
+            edits: Vec::new(),
+            imports: Vec::new(),
+            seen: HashSet::new(),
+            blocked
+        };
+        visitor.visit_file(ast);
+
+        if !visitor.imports.is_empty() {
+            let offset = import_insertion_offset(content);
+            let mut block = visitor.imports.join("\n");
+            block.push('\n');
+            visitor.edits.push(TextEdit {
+                range:       offset..offset,
+                replacement: block
+            });
+        }
+
+        Ok(visitor.edits)
+    }
+}
+
+impl PathImportAnalyzer {
+    /// Finds final identifiers reachable from more than one distinct path.
+    ///
+    /// Rewriting such an identifier to an import would create duplicate or
+    /// ambiguous imports that break compilation, so those paths are left
+    /// qualified.
+    ///
+    /// # Arguments
+    ///
+    /// * `ast` - Parsed file to scan
+    ///
+    /// # Returns
+    ///
+    /// Set of colliding final identifiers
+    fn colliding_idents(ast: &File) -> HashSet<String> {
         let mut collector = PathCollector {
             paths: HashMap::new()
         };
         collector.visit_file(ast);
 
-        let blocked: HashSet<String> = collector
+        collector
             .paths
             .into_iter()
             .filter(|(_, sources)| sources.len() > 1)
             .map(|(ident, _)| ident)
-            .collect();
-
-        let mut fixer = PathFixer {
-            fixed_count: 0,
-            imports: Vec::new(),
-            seen: HashSet::new(),
-            blocked
-        };
-        fixer.visit_file_mut(ast);
-
-        if !fixer.imports.is_empty() {
-            let mut items = std::mem::take(&mut fixer.imports);
-            items.append(&mut ast.items);
-            ast.items = items;
-        }
-
-        Ok(fixer.fixed_count)
+            .collect()
     }
 }
 
@@ -288,50 +308,45 @@ impl<'ast> syn::visit::Visit<'ast> for PathVisitor {
     }
 }
 
-/// Rewrites qualified paths to short names and collects the imports to add.
+/// Produces byte-range edits that drop the module prefix of qualified paths and
+/// collects the `use` statements to insert.
 ///
 /// For each expression path that
-/// [`PathImportAnalyzer::should_extract_to_import`] approves, the leading
-/// segments are dropped so only the final segment (with its generic arguments)
-/// remains, and a matching `use` item is queued for insertion at the top of the
-/// file.
-struct PathFixer {
-    fixed_count: usize,
-    imports:     Vec<Item>,
-    seen:        HashSet<String>,
-    blocked:     HashSet<String>
+/// [`PathImportAnalyzer::should_extract_to_import`] approves and whose final
+/// identifier is not a short-name collision, an edit deletes the leading
+/// segments (`std::fs::` in `std::fs::read`), leaving the final segment and its
+/// generic arguments untouched, and a matching `use` is queued for insertion.
+struct EditVisitor {
+    edits:   Vec<TextEdit>,
+    imports: Vec<String>,
+    seen:    HashSet<String>,
+    blocked: HashSet<String>
 }
 
-impl VisitMut for PathFixer {
-    fn visit_expr_path_mut(&mut self, node: &mut ExprPath) {
-        if node.qself.is_none() && PathImportAnalyzer::should_extract_to_import(&node.path) {
-            let path_str = path_to_string(&node.path);
+impl<'ast> Visit<'ast> for EditVisitor {
+    fn visit_expr_path(&mut self, node: &'ast ExprPath) {
+        if node.qself.is_none()
+            && PathImportAnalyzer::should_extract_to_import(&node.path)
+            && let Some(last) = node.path.segments.last()
+            && !self.blocked.contains(&last.ident.to_string())
+        {
+            let path_start = node.path.span().byte_range().start;
+            let last_start = last.ident.span().byte_range().start;
 
-            let is_blocked = node
-                .path
-                .segments
-                .last()
-                .is_some_and(|last| self.blocked.contains(&last.ident.to_string()));
-
-            if let Some(last) = node.path.segments.last().cloned()
-                && !is_blocked
-            {
-                if self.seen.insert(path_str.clone())
-                    && let Ok(item_use) = syn::parse_str::<ItemUse>(&format!("use {};", path_str))
-                {
-                    self.imports.push(Item::Use(item_use));
+            if last_start > path_start {
+                let path_str = path_to_string(&node.path);
+                if self.seen.insert(path_str.clone()) {
+                    self.imports.push(format!("use {};", path_str));
                 }
 
-                let mut segments = Punctuated::new();
-                segments.push(last);
-                node.path.segments = segments;
-                node.path.leading_colon = None;
-
-                self.fixed_count += 1;
+                self.edits.push(TextEdit {
+                    range:       path_start..last_start,
+                    replacement: String::new()
+                });
             }
         }
 
-        visit_mut::visit_expr_path_mut(self, node);
+        syn::visit::visit_expr_path(self, node);
     }
 }
 
@@ -471,68 +486,69 @@ mod tests {
         assert_eq!(result.issues.len(), 1);
     }
 
+    fn apply_fix(content: &str) -> (usize, String) {
+        let analyzer = PathImportAnalyzer::new();
+        let ast = syn::parse_file(content).unwrap();
+        let edits = analyzer.edits(&ast, content).unwrap();
+        let fixed = edits.iter().filter(|edit| !edit.range.is_empty()).count();
+        let output = crate::fixer::apply_edits(content, edits);
+        (fixed, output)
+    }
+
     #[test]
     fn test_fix_rewrites_path_and_adds_import() {
-        let analyzer = PathImportAnalyzer::new();
-        let mut code: File = parse_quote! {
-            fn main() {
-                let content = std::fs::read_to_string("file.txt");
-            }
-        };
+        let content = "fn main() {\n    let content = std::fs::read_to_string(\"file.txt\");\n}\n";
+        let (fixed, output) = apply_fix(content);
 
-        let fixed = analyzer.fix(&mut code).unwrap();
         assert_eq!(fixed, 1);
-
-        let output = prettyplease::unparse(&code);
         assert!(output.contains("use std::fs::read_to_string;"));
         assert!(output.contains("read_to_string(\"file.txt\")"));
         assert!(!output.contains("std::fs::read_to_string("));
     }
 
     #[test]
-    fn test_fix_returns_zero_without_issues() {
-        let analyzer = PathImportAnalyzer::new();
-        let mut code: File = parse_quote! {
-            fn main() {
-                let v = Vec::new();
-            }
-        };
+    fn test_fix_preserves_comments_and_blank_lines() {
+        let content = "// top comment\nfn main() {\n    // inline note\n    let x = std::fs::read_to_string(\"f\");\n\n    let _ = x;\n}\n";
+        let (fixed, output) = apply_fix(content);
 
-        let fixed = analyzer.fix(&mut code).unwrap();
+        assert_eq!(fixed, 1);
+        assert!(output.contains("// top comment"), "top comment preserved");
+        assert!(
+            output.contains("// inline note"),
+            "inline comment preserved"
+        );
+        assert!(
+            output.contains("\n\n    let _ = x;"),
+            "blank line preserved"
+        );
+        assert!(output.contains("use std::fs::read_to_string;"));
+        assert!(output.contains("let x = read_to_string(\"f\");"));
+    }
+
+    #[test]
+    fn test_fix_returns_zero_without_issues() {
+        let content = "fn main() {\n    let v = Vec::new();\n}\n";
+        let (fixed, output) = apply_fix(content);
+
         assert_eq!(fixed, 0);
+        assert_eq!(output, content);
     }
 
     #[test]
     fn test_fix_dedups_repeated_import() {
-        let analyzer = PathImportAnalyzer::new();
-        let mut code: File = parse_quote! {
-            fn main() {
-                let a = std::fs::read_to_string("a");
-                let b = std::fs::read_to_string("b");
-            }
-        };
+        let content = "fn main() {\n    let a = std::fs::read_to_string(\"a\");\n    let b = std::fs::read_to_string(\"b\");\n}\n";
+        let (fixed, output) = apply_fix(content);
 
-        let fixed = analyzer.fix(&mut code).unwrap();
         assert_eq!(fixed, 2);
-
-        let output = prettyplease::unparse(&code);
         assert_eq!(output.matches("use std::fs::read_to_string;").count(), 1);
     }
 
     #[test]
     fn test_fix_skips_short_name_collision() {
-        let analyzer = PathImportAnalyzer::new();
-        let mut code: File = parse_quote! {
-            fn main() {
-                let a = std::fs::read("x");
-                let b = other::helpers::read("y");
-            }
-        };
+        let content = "fn main() {\n    let a = std::fs::read(\"x\");\n    let b = other::helpers::read(\"y\");\n}\n";
+        let (fixed, output) = apply_fix(content);
 
-        let fixed = analyzer.fix(&mut code).unwrap();
         assert_eq!(fixed, 0);
-
-        let output = prettyplease::unparse(&code);
         assert!(output.contains("std::fs::read(\"x\")"));
         assert!(output.contains("other::helpers::read(\"y\")"));
         assert!(!output.contains("use std::fs::read;"));
@@ -541,34 +557,19 @@ mod tests {
 
     #[test]
     fn test_fix_same_path_repeated_is_not_collision() {
-        let analyzer = PathImportAnalyzer::new();
-        let mut code: File = parse_quote! {
-            fn main() {
-                let a = std::fs::read("x");
-                let b = std::fs::read("y");
-            }
-        };
+        let content = "fn main() {\n    let a = std::fs::read(\"x\");\n    let b = std::fs::read(\"y\");\n}\n";
+        let (fixed, output) = apply_fix(content);
 
-        let fixed = analyzer.fix(&mut code).unwrap();
         assert_eq!(fixed, 2);
-
-        let output = prettyplease::unparse(&code);
         assert_eq!(output.matches("use std::fs::read;").count(), 1);
     }
 
     #[test]
     fn test_fix_preserves_generic_arguments() {
-        let analyzer = PathImportAnalyzer::new();
-        let mut code: File = parse_quote! {
-            fn main() {
-                let size = core::mem::size_of::<u32>();
-            }
-        };
+        let content = "fn main() {\n    let size = core::mem::size_of::<u32>();\n}\n";
+        let (fixed, output) = apply_fix(content);
 
-        let fixed = analyzer.fix(&mut code).unwrap();
         assert_eq!(fixed, 1);
-
-        let output = prettyplease::unparse(&code);
         assert!(output.contains("use core::mem::size_of;"));
         assert!(output.contains("size_of::<u32>()"));
     }

--- a/src/fixer.rs
+++ b/src/fixer.rs
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! Application of byte-range text edits to source code.
+//!
+//! Fixes are expressed as [`crate::analyzer::TextEdit`]s against the original
+//! source and applied here. Because only the edited byte ranges change,
+//! comments, blank lines, and the author's formatting are preserved — unlike
+//! reprinting the AST, which drops comments and reformats the whole file.
+
+use crate::analyzer::TextEdit;
+
+/// Applies non-overlapping text edits to the source.
+///
+/// Edits are applied from the highest start offset to the lowest so that
+/// earlier byte offsets stay valid while later ones are rewritten.
+///
+/// # Arguments
+///
+/// * `source` - Original source code
+/// * `edits` - Non-overlapping byte-range edits
+///
+/// # Returns
+///
+/// The edited source
+///
+/// # Examples
+///
+/// ```
+/// use cargo_quality::{analyzer::TextEdit, fixer::apply_edits};
+///
+/// let src = "let x = std::fs::read(\"f\");";
+/// let edits = vec![TextEdit {
+///     range:       8..17,
+///     replacement: String::new()
+/// }];
+/// assert_eq!(apply_edits(src, edits), "let x = read(\"f\");");
+/// ```
+pub fn apply_edits(source: &str, mut edits: Vec<TextEdit>) -> String {
+    edits.sort_by_key(|edit| std::cmp::Reverse(edit.range.start));
+
+    let mut output = source.to_string();
+    for edit in edits {
+        output.replace_range(edit.range, &edit.replacement);
+    }
+
+    output
+}
+
+/// Computes the byte offset at which to insert `use` statements.
+///
+/// Skips the leading run of blank lines, non-doc `//` comments, module docs
+/// (`//!`), and inner attributes (`#!`), so inserted imports stay valid Rust
+/// and land above the first item.
+///
+/// # Arguments
+///
+/// * `source` - Original source code
+///
+/// # Returns
+///
+/// Byte offset for import insertion
+pub fn import_insertion_offset(source: &str) -> usize {
+    let mut offset = 0;
+
+    for line in source.split_inclusive('\n') {
+        let trimmed = line.trim_start();
+        if trimmed.is_empty()
+            || trimmed.starts_with("//!")
+            || trimmed.starts_with("#!")
+            || (trimmed.starts_with("//") && !trimmed.starts_with("///"))
+        {
+            offset += line.len();
+        } else {
+            break;
+        }
+    }
+
+    offset
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_apply_single_edit() {
+        let src = "abcdef";
+        let edits = vec![TextEdit {
+            range:       2..4,
+            replacement: "XY".to_string()
+        }];
+        assert_eq!(apply_edits(src, edits), "abXYef");
+    }
+
+    #[test]
+    fn test_apply_multiple_non_overlapping_edits() {
+        let src = "one two three";
+        let edits = vec![
+            TextEdit {
+                range:       0..3,
+                replacement: "1".to_string()
+            },
+            TextEdit {
+                range:       8..13,
+                replacement: "3".to_string()
+            },
+        ];
+        assert_eq!(apply_edits(src, edits), "1 two 3");
+    }
+
+    #[test]
+    fn test_apply_deletion() {
+        let src = "let x = std::fs::read(\"f\");";
+        let edits = vec![TextEdit {
+            range:       8..17,
+            replacement: String::new()
+        }];
+        assert_eq!(apply_edits(src, edits), "let x = read(\"f\");");
+    }
+
+    #[test]
+    fn test_apply_no_edits_is_identity() {
+        let src = "unchanged";
+        assert_eq!(apply_edits(src, Vec::new()), "unchanged");
+    }
+
+    #[test]
+    fn test_insertion_offset_skips_module_docs() {
+        let src = "// SPDX header\n//! module doc\n\nuse std::fmt;\nfn main() {}\n";
+        let offset = import_insertion_offset(src);
+        assert_eq!(&src[offset..offset + 3], "use");
+    }
+
+    #[test]
+    fn test_insertion_offset_stops_at_outer_doc() {
+        let src = "/// item doc\nfn main() {}\n";
+        assert_eq!(import_insertion_offset(src), 0);
+    }
+
+    #[test]
+    fn test_insertion_offset_empty_source() {
+        assert_eq!(import_insertion_offset(""), 0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,10 +91,6 @@
 //!     fn analyze(&self, _ast: &File, _content: &str) -> AppResult<AnalysisResult> {
 //!         Ok(AnalysisResult::default())
 //!     }
-//!
-//!     fn fix(&self, _ast: &mut File) -> AppResult<usize> {
-//!         Ok(0)
-//!     }
 //! }
 //! ```
 //!
@@ -117,6 +113,7 @@ pub mod analyzers;
 pub mod differ;
 pub mod error;
 pub mod file_utils;
+pub mod fixer;
 pub mod formatter;
 pub mod mod_rs;
 pub mod report;

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ mod cli;
 mod differ;
 mod error;
 mod file_utils;
+mod fixer;
 mod formatter;
 mod help;
 mod mod_rs;
@@ -580,23 +581,26 @@ fn fix_quality(path: &str, dry_run: bool, analyzer_name: Option<&str>) -> AppRes
         let files = collect_rust_files(path)?;
         for file_path in files {
             let content = fs::read_to_string(&file_path).map_err(IoError::from)?;
-            let mut ast = syn::parse_file(&content).map_err(ParseError::from)?;
+            let ast = syn::parse_file(&content).map_err(ParseError::from)?;
 
-            let mut total_fixed = 0;
-
+            let mut edits = Vec::new();
             for analyzer in &analyzers {
-                let fixed = analyzer.fix(&mut ast)?;
-                total_fixed += fixed;
+                edits.extend(analyzer.edits(&ast, &content)?);
             }
 
-            if total_fixed > 0 {
-                println!("Fixed {} issues in {}", total_fixed, file_path.display());
-
-                if !dry_run {
-                    let formatted = prettyplease::unparse(&ast);
-                    fs::write(&file_path, formatted).map_err(IoError::from)?;
-                }
+            let fixed = edits.iter().filter(|edit| !edit.range.is_empty()).count();
+            if fixed == 0 {
+                continue;
             }
+
+            if dry_run {
+                println!("Would fix {} issues in {}", fixed, file_path.display());
+                continue;
+            }
+
+            let updated = fixer::apply_edits(&content, edits);
+            fs::write(&file_path, updated).map_err(IoError::from)?;
+            println!("Fixed {} issues in {}", fixed, file_path.display());
         }
     }
 


### PR DESCRIPTION
## Summary

`cargo qual fix`/`format` wrote `prettyplease::unparse(&ast)`, which reprints the whole file from the AST — deleting every non-doc comment and blank line and reformatting everything, even for a single import fix.

This replaces the AST-reprint approach with **byte-range text edits applied to the original source**, the way `rustfmt`/`rust-analyzer` apply changes: only the edited ranges change, so comments, blank lines, and formatting are preserved.

## Design

- New `analyzer::TextEdit { range, replacement }` and `fixer::apply_edits` (applies non-overlapping edits highest-offset-first) + `fixer::import_insertion_offset`.
- `Analyzer::fix(&mut File) -> usize` is replaced by `Analyzer::edits(&File, &str) -> Vec<TextEdit>` (default: none). Only `path_import` overrides it.
- `path_import` produces edits from `proc_macro2` `Span::byte_range()`: each edit deletes the module prefix (`std::fs::`) keeping the final segment and its generics, plus deduplicated `use` insertions. Short-name collisions are still skipped (kept from #77).
- `fix_quality` collects edits from all analyzers and applies them; the AST/prettyplease path is gone. `prettyplease` dependency removed.

## Verification

```
// Top-level comment
fn main() {
    // an inline comment explaining
    let x = std::fs::read_to_string("f");

    let y = 42;
}
```
After `fix`: both comments and the blank line are preserved; only `std::fs::read_to_string` → `read_to_string` + `use std::fs::read_to_string;` inserted after the top comment. Output compiles.

New tests cover comment/blank-line preservation, generics, dedup, and collision-safety. `cargo test` (448), `cargo clippy --all-targets --all-features -D warnings`, nightly `fmt --check`, `cargo rdme --check` — green.

Closes #93