### PR TITLE
#95 refactor: unify fix and diff on one collision-safe edit engine

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -33,12 +33,29 @@ use syn::File;
 /// };
 /// assert_eq!(edit.range.len(), 9);
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TextEdit {
     /// Byte range in the original source to replace
     pub range:       Range<usize>,
     /// Text to substitute for the range (empty to delete)
     pub replacement: String
+}
+
+/// A single fixable change: one source edit plus any import it requires.
+///
+/// Both the `fix` command and the diff/interactive flow are built from
+/// suggestions, so applying a change is identical everywhere: the [`edit`] is
+/// spliced into the source and the [`import`], if any, is inserted once
+/// (imports are deduplicated across the applied suggestions).
+///
+/// [`edit`]: Suggestion::edit
+/// [`import`]: Suggestion::import
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Suggestion {
+    /// The byte-range edit that performs the rewrite
+    pub edit:   TextEdit,
+    /// A `use` statement the rewrite depends on, if any
+    pub import: Option<String>
 }
 
 /// Type of fix that can be applied to resolve an issue.
@@ -232,12 +249,12 @@ pub trait Analyzer {
     /// `AppResult<AnalysisResult>` - Analysis results or error
     fn analyze(&self, ast: &File, content: &str) -> AppResult<AnalysisResult>;
 
-    /// Produce byte-range text edits that fix the detected issues.
+    /// Produce fixable suggestions for the detected issues.
     ///
-    /// Edits are applied against the original source, preserving everything
-    /// outside the edited ranges (comments, blank lines, formatting). The
-    /// default implementation returns no edits, for analyzers that are advisory
-    /// only.
+    /// Each suggestion is a byte-range edit (plus an optional import) applied
+    /// against the original source, preserving everything outside the edited
+    /// ranges (comments, blank lines, formatting). The default implementation
+    /// returns none, for analyzers that are advisory only.
     ///
     /// # Arguments
     ///
@@ -246,8 +263,8 @@ pub trait Analyzer {
     ///
     /// # Returns
     ///
-    /// `AppResult<Vec<TextEdit>>` - Non-overlapping edits, or error
-    fn edits(&self, _ast: &File, _content: &str) -> AppResult<Vec<TextEdit>> {
+    /// `AppResult<Vec<Suggestion>>` - Non-overlapping suggestions, or error
+    fn suggestions(&self, _ast: &File, _content: &str) -> AppResult<Vec<Suggestion>> {
         Ok(Vec::new())
     }
 }

--- a/src/analyzers/empty_lines.rs
+++ b/src/analyzers/empty_lines.rs
@@ -379,7 +379,7 @@ mod tests {
 }"#;
         let code = syn::parse_str(content).unwrap();
 
-        let edits = analyzer.edits(&code, content).unwrap();
+        let edits = analyzer.suggestions(&code, content).unwrap();
         assert!(edits.is_empty());
     }
 

--- a/src/analyzers/format_args.rs
+++ b/src/analyzers/format_args.rs
@@ -312,7 +312,7 @@ mod tests {
             }
         };
 
-        let edits = analyzer.edits(&code, "").unwrap();
+        let edits = analyzer.suggestions(&code, "").unwrap();
         assert!(edits.is_empty());
     }
 

--- a/src/analyzers/inline_comments.rs
+++ b/src/analyzers/inline_comments.rs
@@ -402,7 +402,7 @@ impl Foo {
 }"#;
         let code = syn::parse_str(content).unwrap();
 
-        let edits = analyzer.edits(&code, content).unwrap();
+        let edits = analyzer.suggestions(&code, content).unwrap();
         assert!(edits.is_empty());
     }
 

--- a/src/analyzers/path_import.rs
+++ b/src/analyzers/path_import.rs
@@ -15,10 +15,7 @@ use std::collections::{HashMap, HashSet};
 use masterror::AppResult;
 use syn::{ExprPath, File, Path, spanned::Spanned, visit::Visit};
 
-use crate::{
-    analyzer::{AnalysisResult, Analyzer, Fix, Issue, TextEdit},
-    fixer::import_insertion_offset
-};
+use crate::analyzer::{AnalysisResult, Analyzer, Fix, Issue, Suggestion, TextEdit};
 
 /// Analyzer for detecting path separators that should be imports.
 ///
@@ -168,28 +165,16 @@ impl Analyzer for PathImportAnalyzer {
         })
     }
 
-    fn edits(&self, ast: &File, content: &str) -> AppResult<Vec<TextEdit>> {
+    fn suggestions(&self, ast: &File, _content: &str) -> AppResult<Vec<Suggestion>> {
         let blocked = Self::colliding_idents(ast);
 
-        let mut visitor = EditVisitor {
-            edits: Vec::new(),
-            imports: Vec::new(),
-            seen: HashSet::new(),
+        let mut visitor = SuggestionVisitor {
+            suggestions: Vec::new(),
             blocked
         };
         visitor.visit_file(ast);
 
-        if !visitor.imports.is_empty() {
-            let offset = import_insertion_offset(content);
-            let mut block = visitor.imports.join("\n");
-            block.push('\n');
-            visitor.edits.push(TextEdit {
-                range:       offset..offset,
-                replacement: block
-            });
-        }
-
-        Ok(visitor.edits)
+        Ok(visitor.suggestions)
     }
 }
 
@@ -308,22 +293,19 @@ impl<'ast> syn::visit::Visit<'ast> for PathVisitor {
     }
 }
 
-/// Produces byte-range edits that drop the module prefix of qualified paths and
-/// collects the `use` statements to insert.
+/// Produces a fix suggestion for each qualified path that should be imported.
 ///
 /// For each expression path that
 /// [`PathImportAnalyzer::should_extract_to_import`] approves and whose final
-/// identifier is not a short-name collision, an edit deletes the leading
-/// segments (`std::fs::` in `std::fs::read`), leaving the final segment and its
-/// generic arguments untouched, and a matching `use` is queued for insertion.
-struct EditVisitor {
-    edits:   Vec<TextEdit>,
-    imports: Vec<String>,
-    seen:    HashSet<String>,
-    blocked: HashSet<String>
+/// identifier is not a short-name collision, a suggestion carries an edit
+/// deleting the leading segments (`std::fs::` in `std::fs::read`), leaving the
+/// final segment and its generic arguments untouched, plus the matching `use`.
+struct SuggestionVisitor {
+    suggestions: Vec<Suggestion>,
+    blocked:     HashSet<String>
 }
 
-impl<'ast> Visit<'ast> for EditVisitor {
+impl<'ast> Visit<'ast> for SuggestionVisitor {
     fn visit_expr_path(&mut self, node: &'ast ExprPath) {
         if node.qself.is_none()
             && PathImportAnalyzer::should_extract_to_import(&node.path)
@@ -335,13 +317,13 @@ impl<'ast> Visit<'ast> for EditVisitor {
 
             if last_start > path_start {
                 let path_str = path_to_string(&node.path);
-                if self.seen.insert(path_str.clone()) {
-                    self.imports.push(format!("use {};", path_str));
-                }
 
-                self.edits.push(TextEdit {
-                    range:       path_start..last_start,
-                    replacement: String::new()
+                self.suggestions.push(Suggestion {
+                    edit:   TextEdit {
+                        range:       path_start..last_start,
+                        replacement: String::new()
+                    },
+                    import: Some(format!("use {};", path_str))
                 });
             }
         }
@@ -489,9 +471,9 @@ mod tests {
     fn apply_fix(content: &str) -> (usize, String) {
         let analyzer = PathImportAnalyzer::new();
         let ast = syn::parse_file(content).unwrap();
-        let edits = analyzer.edits(&ast, content).unwrap();
-        let fixed = edits.iter().filter(|edit| !edit.range.is_empty()).count();
-        let output = crate::fixer::apply_edits(content, edits);
+        let suggestions = analyzer.suggestions(&ast, content).unwrap();
+        let fixed = suggestions.len();
+        let output = crate::fixer::apply_suggestions(content, &suggestions);
         (fixed, output)
     }
 

--- a/src/differ/apply.rs
+++ b/src/differ/apply.rs
@@ -3,22 +3,24 @@
 
 //! Application of selected diff entries to files on disk.
 //!
-//! Used by interactive mode to write only the changes the user accepted.
-//! Line replacements are keyed by line number and guarded by an equality check
-//! against the recorded original, so a change is skipped if the file no longer
-//! matches what the diff was generated from.
+//! Used by interactive mode to write only the changes the user accepted. Each
+//! entry carries the underlying [`crate::analyzer::TextEdit`], so changes are
+//! applied through the same [`crate::fixer::apply_suggestions`] engine as the
+//! `fix` command — collision-safe and comment-preserving. An entry is skipped
+//! if the file no longer matches the line the diff was generated from.
 
 use std::fs;
 
 use masterror::AppResult;
 
 use super::types::{DiffResult, FileDiff};
-use crate::error::IoError;
+use crate::{analyzer::Suggestion, error::IoError, fixer::apply_suggestions};
 
 /// Applies selected diff entries to their files.
 ///
-/// For each file, replaces recorded lines with their modified form and inserts
-/// deduplicated `use` imports after leading module docs and inner attributes.
+/// Each file's accepted entries are turned back into suggestions and applied
+/// through [`apply_suggestions`], so the result is collision-safe and preserves
+/// comments and formatting — identical to the `fix` command.
 ///
 /// # Arguments
 ///
@@ -56,146 +58,65 @@ fn apply_file(file: &FileDiff) -> AppResult<usize> {
     }
 
     let content = fs::read_to_string(&file.path).map_err(IoError::from)?;
-    let mut lines: Vec<String> = content.lines().map(str::to_string).collect();
-    let mut imports: Vec<String> = Vec::new();
-    let mut applied = 0;
+    let lines: Vec<&str> = content.lines().collect();
 
+    let mut suggestions = Vec::new();
     for entry in &file.entries {
         let idx = entry.line.saturating_sub(1);
-
-        let Some(line) = lines.get_mut(idx) else {
-            continue;
-        };
-
-        if *line != entry.original {
-            continue;
+        if lines.get(idx).is_some_and(|line| *line == entry.original) {
+            suggestions.push(Suggestion {
+                edit:   entry.edit.clone(),
+                import: entry.import.clone()
+            });
         }
-
-        *line = entry.modified.clone();
-
-        if let Some(import) = &entry.import
-            && !imports.contains(import)
-        {
-            imports.push(import.clone());
-        }
-
-        applied += 1;
     }
 
-    if applied == 0 {
+    if suggestions.is_empty() {
         return Ok(0);
     }
 
-    insert_imports(&mut lines, imports);
+    let updated = apply_suggestions(&content, &suggestions);
+    fs::write(&file.path, updated).map_err(IoError::from)?;
 
-    let mut text = lines.join("\n");
-    if content.ends_with('\n') {
-        text.push('\n');
-    }
-
-    fs::write(&file.path, text).map_err(IoError::from)?;
-
-    Ok(applied)
-}
-
-/// Inserts import lines after leading module docs and inner attributes.
-///
-/// Skips a leading run of blank lines, non-doc `//` comments, module docs
-/// (`//!`), and inner attributes (`#!`) so the imports remain valid Rust.
-///
-/// # Arguments
-///
-/// * `lines` - File lines to modify in place
-/// * `imports` - Deduplicated import statements to insert
-fn insert_imports(lines: &mut Vec<String>, imports: Vec<String>) {
-    if imports.is_empty() {
-        return;
-    }
-
-    let mut insert_at = 0;
-    for (index, line) in lines.iter().enumerate() {
-        let trimmed = line.trim_start();
-        if trimmed.is_empty()
-            || trimmed.starts_with("//!")
-            || trimmed.starts_with("#!")
-            || (trimmed.starts_with("//") && !trimmed.starts_with("///"))
-        {
-            insert_at = index + 1;
-        } else {
-            break;
-        }
-    }
-
-    for (offset, import) in imports.into_iter().enumerate() {
-        lines.insert(insert_at + offset, import);
-    }
+    Ok(suggestions.len())
 }
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use tempfile::TempDir;
 
     use super::*;
-    use crate::differ::types::DiffEntry;
+    use crate::analyzers::get_analyzers;
 
-    fn entry(line: usize, original: &str, modified: &str, import: Option<&str>) -> DiffEntry {
-        DiffEntry {
-            line,
-            analyzer: "path_import".to_string(),
-            original: original.to_string(),
-            modified: modified.to_string(),
-            description: "desc".to_string(),
-            import: import.map(str::to_string)
-        }
+    fn diff_for(path: &Path) -> DiffResult {
+        let file = super::super::generate_diff(path.to_str().unwrap(), &get_analyzers()).unwrap();
+        let mut result = DiffResult::new();
+        result.add_file(file);
+        result
     }
 
     #[test]
-    fn test_apply_rewrites_line_and_inserts_import() {
+    fn test_apply_rewrites_and_preserves_comments() {
         let temp = TempDir::new().unwrap();
         let path = temp.path().join("a.rs");
         fs::write(
             &path,
-            "//! Module doc\n\nfn main() {\n    let x = std::fs::read_to_string(\"f\");\n}\n"
+            "//! Module doc\n\nfn main() {\n    // note\n    let x = std::fs::read_to_string(\"f\");\n}\n"
         )
         .unwrap();
 
-        let mut result = DiffResult::new();
-        let mut file = FileDiff::new(path.to_str().unwrap().to_string());
-        file.add_entry(entry(
-            4,
-            "    let x = std::fs::read_to_string(\"f\");",
-            "    let x = read_to_string(\"f\");",
-            Some("use std::fs::read_to_string;")
-        ));
-        result.add_file(file);
-
-        let applied = apply_diff(&result).unwrap();
+        let applied = apply_diff(&diff_for(&path)).unwrap();
         assert_eq!(applied, 1);
 
         let output = fs::read_to_string(&path).unwrap();
         assert!(output.contains("use std::fs::read_to_string;"));
         assert!(output.contains("let x = read_to_string(\"f\");"));
         assert!(!output.contains("std::fs::read_to_string("));
+        assert!(output.contains("// note"), "comment preserved");
         assert!(output.starts_with("//! Module doc"));
         assert!(output.ends_with('\n'));
-    }
-
-    #[test]
-    fn test_apply_skips_mismatched_original() {
-        let temp = TempDir::new().unwrap();
-        let path = temp.path().join("b.rs");
-        fs::write(&path, "fn main() {\n    let x = 1;\n}\n").unwrap();
-
-        let mut result = DiffResult::new();
-        let mut file = FileDiff::new(path.to_str().unwrap().to_string());
-        file.add_entry(entry(2, "    let x = 2;", "    let x = changed;", None));
-        result.add_file(file);
-
-        let applied = apply_diff(&result).unwrap();
-        assert_eq!(applied, 0);
-
-        let output = fs::read_to_string(&path).unwrap();
-        assert!(output.contains("let x = 1;"));
     }
 
     #[test]
@@ -208,23 +129,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut result = DiffResult::new();
-        let mut file = FileDiff::new(path.to_str().unwrap().to_string());
-        file.add_entry(entry(
-            2,
-            "    let a = std::fs::read_to_string(\"a\");",
-            "    let a = read_to_string(\"a\");",
-            Some("use std::fs::read_to_string;")
-        ));
-        file.add_entry(entry(
-            3,
-            "    let b = std::fs::read_to_string(\"b\");",
-            "    let b = read_to_string(\"b\");",
-            Some("use std::fs::read_to_string;")
-        ));
-        result.add_file(file);
-
-        let applied = apply_diff(&result).unwrap();
+        let applied = apply_diff(&diff_for(&path)).unwrap();
         assert_eq!(applied, 2);
 
         let output = fs::read_to_string(&path).unwrap();
@@ -232,9 +137,52 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_empty_result() {
-        let result = DiffResult::new();
+    fn test_apply_is_collision_safe() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("d.rs");
+        fs::write(
+            &path,
+            "fn main() {\n    let a = std::fs::read(\"x\");\n    let b = other::helpers::read(\"y\");\n}\n"
+        )
+        .unwrap();
+
+        let result = diff_for(&path);
+        assert_eq!(
+            result.total_changes(),
+            0,
+            "colliding reads produce no changes"
+        );
+
         let applied = apply_diff(&result).unwrap();
+        assert_eq!(applied, 0);
+        assert!(
+            fs::read_to_string(&path)
+                .unwrap()
+                .contains("std::fs::read(\"x\")")
+        );
+    }
+
+    #[test]
+    fn test_apply_skips_when_file_changed() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("e.rs");
+        fs::write(
+            &path,
+            "fn main() {\n    let x = std::fs::read_to_string(\"f\");\n}\n"
+        )
+        .unwrap();
+
+        let result = diff_for(&path);
+        fs::write(&path, "fn main() {\n    let y = 1;\n}\n").unwrap();
+
+        let applied = apply_diff(&result).unwrap();
+        assert_eq!(applied, 0, "stale entry is skipped");
+        assert!(fs::read_to_string(&path).unwrap().contains("let y = 1;"));
+    }
+
+    #[test]
+    fn test_apply_empty_result() {
+        let applied = apply_diff(&DiffResult::new()).unwrap();
         assert_eq!(applied, 0);
     }
 }

--- a/src/differ/display.rs
+++ b/src/differ/display.rs
@@ -368,7 +368,7 @@ pub fn show_interactive(result: &DiffResult, color: bool) -> AppResult<DiffResul
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::differ::types::DiffEntry;
+    use crate::{analyzer::TextEdit, differ::types::DiffEntry};
 
     #[test]
     fn test_show_summary_empty() {
@@ -393,7 +393,8 @@ mod tests {
             original:    "old".to_string(),
             modified:    "new".to_string(),
             description: "desc".to_string(),
-            import:      None
+            import:      None,
+            edit:        TextEdit::default()
         });
 
         result.add_file(file);
@@ -411,7 +412,8 @@ mod tests {
             original:    "old".to_string(),
             modified:    "new".to_string(),
             description: "desc".to_string(),
-            import:      None
+            import:      None,
+            edit:        TextEdit::default()
         });
 
         result.add_file(file);

--- a/src/differ/display/render.rs
+++ b/src/differ/display/render.rs
@@ -334,7 +334,10 @@ fn render_footer(lines: &mut Vec<String>, max_width: &mut usize, color: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::differ::types::{DiffEntry, FileDiff};
+    use crate::{
+        analyzer::TextEdit,
+        differ::types::{DiffEntry, FileDiff}
+    };
 
     #[test]
     fn test_render_file_block_empty() {
@@ -354,7 +357,8 @@ mod tests {
             original:    "old".to_string(),
             modified:    "new".to_string(),
             description: "desc".to_string(),
-            import:      None
+            import:      None,
+            edit:        TextEdit::default()
         });
 
         let rendered = render_file_block(&file, false);
@@ -370,7 +374,8 @@ mod tests {
             original:    "std::fs::read()".to_string(),
             modified:    "read()".to_string(),
             description: "Use import".to_string(),
-            import:      Some("use std::fs::read;".to_string())
+            import:      Some("use std::fs::read;".to_string()),
+            edit:        TextEdit::default()
         });
 
         let rendered = render_file_block(&file, false);
@@ -387,7 +392,8 @@ mod tests {
             original:    "old1".to_string(),
             modified:    "new1".to_string(),
             description: "desc1".to_string(),
-            import:      None
+            import:      None,
+            edit:        TextEdit::default()
         });
 
         file.add_entry(DiffEntry {
@@ -396,7 +402,8 @@ mod tests {
             original:    "old2".to_string(),
             modified:    "new2".to_string(),
             description: "desc2".to_string(),
-            import:      None
+            import:      None,
+            edit:        TextEdit::default()
         });
 
         let rendered = render_file_block(&file, false);

--- a/src/differ/generator.rs
+++ b/src/differ/generator.rs
@@ -7,7 +7,7 @@ use masterror::AppResult;
 
 use super::types::{DiffEntry, FileDiff};
 use crate::{
-    analyzer::Analyzer,
+    analyzer::{Analyzer, Suggestion},
     error::{IoError, ParseError}
 };
 
@@ -37,42 +37,61 @@ pub fn generate_diff(file_path: &str, analyzers: &[Box<dyn Analyzer>]) -> AppRes
     let mut file_diff = FileDiff::new(file_path.to_string());
 
     for analyzer in analyzers {
-        let result = analyzer.analyze(&ast, &content)?;
-
-        for issue in result.issues {
-            if issue.line == 0 || !issue.fix.is_available() {
-                continue;
-            }
-
-            let original_content = content
-                .lines()
-                .nth(issue.line.saturating_sub(1))
-                .unwrap_or("");
-
-            let (modified_line, import) =
-                if let Some((import, pattern, replacement)) = issue.fix.as_import() {
-                    let modified = original_content.replace(pattern, replacement);
-                    (modified, Some(import.to_string()))
-                } else if let Some(simple) = issue.fix.as_simple() {
-                    (simple.to_string(), None)
-                } else {
-                    continue;
-                };
-
-            let entry = DiffEntry {
-                line: issue.line,
-                analyzer: analyzer.name().to_string(),
-                original: original_content.to_string(),
-                modified: modified_line,
-                description: issue.message,
-                import
-            };
-
-            file_diff.add_entry(entry);
+        for suggestion in analyzer.suggestions(&ast, &content)? {
+            file_diff.add_entry(entry_from_suggestion(analyzer.name(), &content, suggestion));
         }
     }
 
     Ok(file_diff)
+}
+
+/// Builds a displayable diff entry from a fix suggestion.
+///
+/// Derives the affected line number and its before/after text from the
+/// suggestion's byte-range edit, and keeps the edit for application.
+///
+/// # Arguments
+///
+/// * `analyzer` - Name of the analyzer that produced the suggestion
+/// * `content` - Original source code
+/// * `suggestion` - Suggestion to render
+///
+/// # Returns
+///
+/// A `DiffEntry` for display and application
+fn entry_from_suggestion(analyzer: &str, content: &str, suggestion: Suggestion) -> DiffEntry {
+    let start = suggestion.edit.range.start;
+    let end = suggestion.edit.range.end;
+
+    let line = content[..start]
+        .bytes()
+        .filter(|&byte| byte == b'\n')
+        .count()
+        + 1;
+    let line_start = content[..start].rfind('\n').map_or(0, |index| index + 1);
+    let line_end = content[start..]
+        .find('\n')
+        .map_or(content.len(), |index| start + index);
+
+    let original = content[line_start..line_end].to_string();
+    let rel_start = start - line_start;
+    let rel_end = (end - line_start).min(original.len());
+    let modified = format!(
+        "{}{}{}",
+        &original[..rel_start],
+        suggestion.edit.replacement,
+        &original[rel_end..]
+    );
+
+    DiffEntry {
+        line,
+        analyzer: analyzer.to_string(),
+        original,
+        modified,
+        description: format!("{} fix", analyzer),
+        import: suggestion.import,
+        edit: suggestion.edit
+    }
 }
 
 #[cfg(test)]

--- a/src/differ/types.rs
+++ b/src/differ/types.rs
@@ -1,9 +1,13 @@
 // SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
+use crate::analyzer::TextEdit;
+
 /// Represents a single code change.
 ///
-/// Stores the location and content of a proposed modification.
+/// Stores the location and content of a proposed modification for display, and
+/// the underlying [`TextEdit`] so the same change can be applied through the
+/// shared fix engine.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiffEntry {
     pub line:        usize,
@@ -11,7 +15,8 @@ pub struct DiffEntry {
     pub original:    String,
     pub modified:    String,
     pub description: String,
-    pub import:      Option<String>
+    pub import:      Option<String>,
+    pub edit:        TextEdit
 }
 
 /// Diff results for a single file.
@@ -134,7 +139,8 @@ mod tests {
             original:    "old".to_string(),
             modified:    "new".to_string(),
             description: "desc".to_string(),
-            import:      None
+            import:      None,
+            edit:        TextEdit::default()
         };
 
         assert_eq!(entry.line, 10);
@@ -157,7 +163,8 @@ mod tests {
             original:    "old".to_string(),
             modified:    "new".to_string(),
             description: "desc".to_string(),
-            import:      None
+            import:      None,
+            edit:        TextEdit::default()
         };
 
         diff.add_entry(entry);
@@ -182,7 +189,8 @@ mod tests {
             original:    "old".to_string(),
             modified:    "new".to_string(),
             description: "desc".to_string(),
-            import:      None
+            import:      None,
+            edit:        TextEdit::default()
         };
 
         file_diff.add_entry(entry);
@@ -212,7 +220,8 @@ mod tests {
             original:    "old".to_string(),
             modified:    "new".to_string(),
             description: "desc".to_string(),
-            import:      None
+            import:      None,
+            edit:        TextEdit::default()
         });
 
         let mut file2 = FileDiff::new("file2.rs".to_string());
@@ -222,7 +231,8 @@ mod tests {
             original:    "old".to_string(),
             modified:    "new".to_string(),
             description: "desc".to_string(),
-            import:      None
+            import:      None,
+            edit:        TextEdit::default()
         });
 
         result.add_file(file1);

--- a/src/fixer.rs
+++ b/src/fixer.rs
@@ -8,7 +8,49 @@
 //! comments, blank lines, and the author's formatting are preserved — unlike
 //! reprinting the AST, which drops comments and reformats the whole file.
 
-use crate::analyzer::TextEdit;
+use std::collections::HashSet;
+
+use crate::analyzer::{Suggestion, TextEdit};
+
+/// Applies fix suggestions to the source, deduplicating their imports.
+///
+/// Collects each suggestion's rewrite edit, inserts every distinct required
+/// import once at the top of the file, and applies them via [`apply_edits`].
+/// Comments, blank lines, and formatting outside the edits are preserved.
+///
+/// # Arguments
+///
+/// * `source` - Original source code
+/// * `suggestions` - Suggestions to apply
+///
+/// # Returns
+///
+/// The edited source
+pub fn apply_suggestions(source: &str, suggestions: &[Suggestion]) -> String {
+    let mut edits: Vec<TextEdit> = suggestions.iter().map(|s| s.edit.clone()).collect();
+
+    let mut seen = HashSet::new();
+    let mut imports = Vec::new();
+    for suggestion in suggestions {
+        if let Some(import) = &suggestion.import
+            && seen.insert(import.clone())
+        {
+            imports.push(import.clone());
+        }
+    }
+
+    if !imports.is_empty() {
+        let offset = import_insertion_offset(source);
+        let mut block = imports.join("\n");
+        block.push('\n');
+        edits.push(TextEdit {
+            range:       offset..offset,
+            replacement: block
+        });
+    }
+
+    apply_edits(source, edits)
+}
 
 /// Applies non-overlapping text edits to the source.
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -583,12 +583,12 @@ fn fix_quality(path: &str, dry_run: bool, analyzer_name: Option<&str>) -> AppRes
             let content = fs::read_to_string(&file_path).map_err(IoError::from)?;
             let ast = syn::parse_file(&content).map_err(ParseError::from)?;
 
-            let mut edits = Vec::new();
+            let mut suggestions = Vec::new();
             for analyzer in &analyzers {
-                edits.extend(analyzer.edits(&ast, &content)?);
+                suggestions.extend(analyzer.suggestions(&ast, &content)?);
             }
 
-            let fixed = edits.iter().filter(|edit| !edit.range.is_empty()).count();
+            let fixed = suggestions.len();
             if fixed == 0 {
                 continue;
             }
@@ -598,7 +598,7 @@ fn fix_quality(path: &str, dry_run: bool, analyzer_name: Option<&str>) -> AppRes
                 continue;
             }
 
-            let updated = fixer::apply_edits(&content, edits);
+            let updated = fixer::apply_suggestions(&content, &suggestions);
             fs::write(&file_path, updated).map_err(IoError::from)?;
             println!("Fixed {} issues in {}", fixed, file_path.display());
         }


### PR DESCRIPTION
## Summary

After #93, `fix` used collision-safe byte-range edits while `diff`/`diff --interactive` still used a separate line-based path with no collision guard — interactively applying two same-named imports from different modules could produce duplicate/ambiguous imports.

Both commands now flow through one engine.

## Design

- `analyzer::Suggestion { edit: TextEdit, import: Option<String> }` and `Analyzer::suggestions(&File, &str)` (default none; `path_import` implements it, collision-safe).
- `fixer::apply_suggestions` collects rewrite edits, dedups imports, and applies via `apply_edits` (preserves comments/formatting).
- `fix` and `generate_diff` both source from `suggestions`; `DiffEntry` carries the underlying `TextEdit`; `apply_diff` reconstructs suggestions from the accepted entries (guarded by a line-match check) and applies them through `apply_suggestions`.

## Verification

- Interactive apply on two colliding `read` paths → `No changes proposed` (collision-safe); non-colliding case applies both, dedups imports, preserves `// header`, `// note`, and blank lines.
- New `apply` tests: comment preservation, import dedup, collision-safety, stale-file skip.
- `cargo test` (450), `cargo clippy --all-targets --all-features -D warnings`, nightly `fmt --check`, `cargo rdme --check` — green.

Closes #95