### PR TITLE
#97 chore: bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cargo-quality"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-quality"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 authors = ["RAprogramm <andrey.rozanov.vl@gmail.com>"]
 description = "Professional Rust code quality analysis tool with hardcoded standards"


### PR DESCRIPTION
## Summary

Release the accumulated work on main (unreleased since 0.3.0). Minor bump: non-destructive collision-safe fix engine, `check` CI-gate exit code, string-literal false-positive fix, mod_rs data-loss guard + ignore support, GitHub Action and completions fixes, README auto-sync.

Merging to main triggers the tag `v0.4.0` + GitHub Release + crates.io publish.

Closes #97