### PR TITLE
#100 fix: guard grep exit status in action count parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cargo-quality"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-quality"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 authors = ["RAprogramm <andrey.rozanov.vl@gmail.com>"]
 description = "Professional Rust code quality analysis tool with hardcoded standards"

--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,7 @@ runs:
         echo "$OUTPUT"
 
         count_for() {
-          echo "$OUTPUT" | grep -oP "\[$1\] - \K\d+" | head -1
+          { echo "$OUTPUT" | grep -oP "\[$1\] - \K\d+" || true; } | head -1
         }
 
         PATH_IMPORT=$(count_for path_import); PATH_IMPORT=${PATH_IMPORT:-0}
@@ -102,7 +102,7 @@ runs:
         INLINE_COMMENTS=$(count_for inline_comments); INLINE_COMMENTS=${INLINE_COMMENTS:-0}
         MOD_RS=$(count_for mod_rs); MOD_RS=${MOD_RS:-0}
 
-        TOTAL=$(echo "$OUTPUT" | grep -oP 'Total issues:\s*\K\d+' | head -1)
+        TOTAL=$({ echo "$OUTPUT" | grep -oP 'Total issues:\s*\K\d+' || true; } | head -1)
         TOTAL=${TOTAL:-0}
 
         echo "total_issues=$TOTAL" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Closes #100

Under the runner default bash flags (-e -o pipefail), count_for and the TOTAL extraction abort the analyze step when grep finds no matches — i.e. exactly when the scanned repository is fully clean. The job then fails with exit code 1 immediately after printing "Total issues: 0".

Guarded both greps with || true inside a group so empty matches fall through to the existing :-0 defaults.

Verified by simulating the step under bash -e -o pipefail for both zero-issue and nonzero-issue outputs.