### PR TITLE
#104 fix: scope-aware path_import rewrites with per-module import insertion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -58,35 +58,35 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -99,29 +99,29 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cargo-quality"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -132,7 +132,7 @@ dependencies = [
  "owo-colors",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
  "tempfile",
  "terminal_size",
  "unicode-width",
@@ -146,9 +146,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.48"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -199,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -211,36 +211,36 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.7"
+version = "4.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
@@ -251,7 +251,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "unicode-width",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -306,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -325,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "encode_unicode"
@@ -380,44 +380,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
+name = "futures-core"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
 ]
 
 [[package]]
 name = "globset"
-version = "0.4.18"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -451,29 +468,28 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "ignore"
-version = "0.4.28"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adf14691c72bcfc1058740436a35bdd3ae9c07d1a941ef00b749e9ea16aefa7"
+checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -512,25 +528,26 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.81"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -540,15 +557,15 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "masterror"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e856b98b2569d0186c833d8a369af5ea2f37ff399a11fe2702798f7d0a97970"
+checksum = "bd170c26e8f0a3c3f1d1552d5a1f6271cbe23cf3c9b50f2fe2b803c37cd88756"
 dependencies = [
  "http",
  "itoa",
@@ -563,27 +580,27 @@ dependencies = [
 
 [[package]]
 name = "masterror-derive"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "821b3dfc91c3aab149eb185d831d1b5ed350a39575ce6b21389d38ea2bddbc90"
+checksum = "37f9fe3a3eb03ef6e56c0dac724b93d6a920dcb1e91ef82cd94b728dfddf1959"
 dependencies = [
  "masterror-template",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "masterror-template"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa90f9eaa68a5c3a60b2322bd19d16ac5cf54e0dba3fdca6cc649fa1317b27d1"
+checksum = "4268f28cdc36feb4184ccb0f1f2d70075efb8cce2669c7fb8220450c74e7217c"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "num-traits"
@@ -596,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -627,6 +644,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "plotters"
@@ -658,33 +681,33 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -702,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -714,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -725,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustix"
@@ -739,20 +762,20 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -765,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -775,35 +798,35 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -828,9 +851,15 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "strsim"
@@ -840,9 +869,20 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -859,7 +899,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -869,7 +909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -884,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -908,18 +948,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "typenum"
@@ -929,9 +969,9 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.20"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-width"
@@ -947,9 +987,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -966,19 +1006,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.104"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -988,24 +1019,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.104"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1013,31 +1030,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.104"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
- "wasm-bindgen-backend",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.104"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.81"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1065,7 +1082,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1082,15 +1099,6 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -1099,98 +1107,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-quality"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 authors = ["RAprogramm <andrey.rozanov.vl@gmail.com>"]
 description = "Professional Rust code quality analysis tool with hardcoded standards"
@@ -12,12 +12,12 @@ readme = "README.md"
 keywords = ["cargo", "quality", "formatter", "analyzer", "linter"]
 categories = ["development-tools", "command-line-utilities"]
 exclude = [".github", "target", ".git", "artifacts", "RELEASE_NOTES.md"]
-rust-version = "1.96"
+rust-version = "1.98"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
-syn = { version = "2", features = [
+syn = { version = "3", features = [
   "full",
   "extra-traits",
   "visit",
@@ -25,7 +25,7 @@ syn = { version = "2", features = [
 ] }
 quote = "1"
 proc-macro2 = { version = "1", features = ["span-locations"] }
-masterror = "0.29"
+masterror = "0.30"
 ignore = "0.4"
 owo-colors = "4"
 terminal_size = "0.4"

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -41,12 +41,38 @@ pub struct TextEdit {
     pub replacement: String
 }
 
+/// A `use` statement insertion anchored to a specific byte offset.
+///
+/// The offset addresses the module that must receive the import — the top of
+/// the file for top-level rewrites, or the first item of an inline module for
+/// rewrites inside it — so the inserted name is always in scope at the rewrite
+/// site.
+///
+/// # Examples
+///
+/// ```
+/// use cargo_quality::analyzer::ImportEdit;
+///
+/// let import = ImportEdit {
+///     offset:    0,
+///     statement: "use std::fs::read;".to_string()
+/// };
+/// assert!(import.statement.starts_with("use "));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportEdit {
+    /// Byte offset in the original source at which to insert the statement
+    pub offset:    usize,
+    /// The `use` statement to insert, without a trailing newline
+    pub statement: String
+}
+
 /// A single fixable change: one source edit plus any import it requires.
 ///
 /// Both the `fix` command and the diff/interactive flow are built from
 /// suggestions, so applying a change is identical everywhere: the [`edit`] is
-/// spliced into the source and the [`import`], if any, is inserted once
-/// (imports are deduplicated across the applied suggestions).
+/// spliced into the source and the [`import`], if any, is inserted once per
+/// target offset (imports are deduplicated across the applied suggestions).
 ///
 /// [`edit`]: Suggestion::edit
 /// [`import`]: Suggestion::import
@@ -55,7 +81,7 @@ pub struct Suggestion {
     /// The byte-range edit that performs the rewrite
     pub edit:   TextEdit,
     /// A `use` statement the rewrite depends on, if any
-    pub import: Option<String>
+    pub import: Option<ImportEdit>
 }
 
 /// Type of fix that can be applied to resolve an issue.

--- a/src/analyzers/path_import.rs
+++ b/src/analyzers/path_import.rs
@@ -5,17 +5,34 @@
 //!
 //! This analyzer identifies module paths with `::` that should be moved to
 //! import statements. It distinguishes between:
-//! - Free functions from modules (should be imported)
+//! - Free functions from absolute module paths (should be imported)
 //! - Associated functions on types (should NOT be imported)
 //! - Enum variants (should NOT be imported)
 //! - Associated constants (should NOT be imported)
+//!
+//! Only absolute paths — rooted at `std`, `core`, `alloc`, or `crate` — are
+//! rewritten. Relative paths (including `self::` and `super::`) resolve
+//! against the module they appear in, so hoisting them into a `use` statement
+//! would change their meaning.
+//!
+//! Fixes are scope-aware: each rewrite consults a per-module symbol table
+//! built from the file (item definitions, `use`-bound names, glob imports,
+//! and local bindings), the required `use` statement is inserted into the
+//! module containing the rewritten path, and a rewrite is skipped whenever
+//! the bare name could collide with or silently rebind an existing name.
 
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    ops::Range
+};
 
 use masterror::AppResult;
-use syn::{ExprPath, File, Path, spanned::Spanned, visit::Visit};
+use syn::{ExprPath, File, Item, ItemUse, Path, UseTree, spanned::Spanned, visit::Visit};
 
-use crate::analyzer::{AnalysisResult, Analyzer, Fix, Issue, Suggestion, TextEdit};
+use crate::{
+    analyzer::{AnalysisResult, Analyzer, Fix, ImportEdit, Issue, Suggestion, TextEdit},
+    fixer::import_insertion_offset
+};
 
 /// Analyzer for detecting path separators that should be imports.
 ///
@@ -45,7 +62,9 @@ impl PathImportAnalyzer {
 
     /// Determine if path should be extracted to import statement.
     ///
-    /// Analyzes path segments to distinguish module paths from type paths.
+    /// Only absolute paths rooted at `std`, `core`, `alloc`, or `crate` whose
+    /// final segment names a free function are accepted. Type paths, enum
+    /// variants, associated items, and relative module paths are rejected.
     ///
     /// # Arguments
     ///
@@ -107,15 +126,7 @@ impl PathImportAnalyzer {
             }
         }
 
-        if Self::is_stdlib_root(&first_name) {
-            return true;
-        }
-
-        if path.segments.len() >= 3 && first_char.is_lowercase() {
-            return true;
-        }
-
-        false
+        Self::is_extractable_root(&first_name)
     }
 
     /// Check if identifier is SCREAMING_SNAKE_CASE constant.
@@ -132,17 +143,21 @@ impl PathImportAnalyzer {
             .all(|c| c.is_uppercase() || c == '_' || c.is_numeric())
     }
 
-    /// Check if name is standard library root module.
+    /// Check if name roots an absolute path that is safe to import from.
+    ///
+    /// Relative roots (module names, `self`, `super`) resolve against the
+    /// module the path appears in, so hoisting them into a `use` statement
+    /// would change their meaning.
     ///
     /// # Arguments
     ///
-    /// * `name` - Module name to check
+    /// * `name` - Root segment name to check
     ///
     /// # Returns
     ///
-    /// `true` if name is `std`, `core`, or `alloc`
-    fn is_stdlib_root(name: &str) -> bool {
-        matches!(name, "std" | "core" | "alloc")
+    /// `true` if name is `std`, `core`, `alloc`, or `crate`
+    fn is_extractable_root(name: &str) -> bool {
+        matches!(name, "std" | "core" | "alloc" | "crate")
     }
 }
 
@@ -165,45 +180,13 @@ impl Analyzer for PathImportAnalyzer {
         })
     }
 
-    fn suggestions(&self, ast: &File, _content: &str) -> AppResult<Vec<Suggestion>> {
-        let blocked = Self::colliding_idents(ast);
+    fn suggestions(&self, ast: &File, content: &str) -> AppResult<Vec<Suggestion>> {
+        let root = ModuleScope::build(&ast.items, Some(import_insertion_offset(content)));
 
-        let mut visitor = SuggestionVisitor {
-            suggestions: Vec::new(),
-            blocked
-        };
-        visitor.visit_file(ast);
+        let mut suggestions = Vec::new();
+        root.collect_suggestions(&HashSet::new(), false, &mut suggestions);
 
-        Ok(visitor.suggestions)
-    }
-}
-
-impl PathImportAnalyzer {
-    /// Finds final identifiers reachable from more than one distinct path.
-    ///
-    /// Rewriting such an identifier to an import would create duplicate or
-    /// ambiguous imports that break compilation, so those paths are left
-    /// qualified.
-    ///
-    /// # Arguments
-    ///
-    /// * `ast` - Parsed file to scan
-    ///
-    /// # Returns
-    ///
-    /// Set of colliding final identifiers
-    fn colliding_idents(ast: &File) -> HashSet<String> {
-        let mut collector = PathCollector {
-            paths: HashMap::new()
-        };
-        collector.visit_file(ast);
-
-        collector
-            .paths
-            .into_iter()
-            .filter(|(_, sources)| sources.len() > 1)
-            .map(|(ident, _)| ident)
-            .collect()
+        Ok(suggestions)
     }
 }
 
@@ -224,28 +207,342 @@ fn path_to_string(path: &Path) -> String {
         .join("::")
 }
 
-/// Collects the final identifier of each extractable path and its source paths.
+/// Name an item binds in its enclosing module, if any.
 ///
-/// Used to detect short-name collisions: an identifier reachable from more than
-/// one distinct full path cannot be safely rewritten to an import.
-struct PathCollector {
-    paths: HashMap<String, HashSet<String>>
+/// # Arguments
+///
+/// * `item` - Item to inspect
+///
+/// # Returns
+///
+/// The bound identifier, or `None` for items that bind no single name
+fn item_bound_name(item: &Item) -> Option<String> {
+    match item {
+        Item::Const(item) => Some(item.ident.to_string()),
+        Item::Enum(item) => Some(item.ident.to_string()),
+        Item::ExternCrate(item) => Some(
+            item.rename
+                .as_ref()
+                .map_or_else(|| item.ident.to_string(), |(_, rename)| rename.to_string())
+        ),
+        Item::Fn(item) => Some(item.sig.ident.to_string()),
+        Item::Macro(item) => item.ident.as_ref().map(|ident| ident.to_string()),
+        Item::Mod(item) => Some(item.ident.to_string()),
+        Item::Static(item) => Some(item.ident.to_string()),
+        Item::Struct(item) => Some(item.ident.to_string()),
+        Item::Trait(item) => Some(item.ident.to_string()),
+        Item::TraitAlias(item) => Some(item.ident.to_string()),
+        Item::Type(item) => Some(item.ident.to_string()),
+        Item::Union(item) => Some(item.ident.to_string()),
+        _ => None
+    }
 }
 
-impl<'ast> Visit<'ast> for PathCollector {
+/// A qualified path eligible for rewriting to a bare imported name.
+struct Candidate {
+    /// Full colon-joined path
+    path:  String,
+    /// Final segment the rewrite leaves behind
+    ident: String,
+    /// Byte range of the leading segments to delete
+    range: Range<usize>
+}
+
+/// Names one module binds and the bare identifiers its code relies on.
+///
+/// Mirrors how name resolution sees the module: names bound by items, `use`
+/// statements, and local bindings, whether glob imports bring in unknown
+/// names, and which bare identifiers the module's code already uses.
+#[derive(Default)]
+struct SymbolTable {
+    /// Names bound in this module: items, `use`-bound names, local bindings
+    bound:            HashSet<String>,
+    /// Bare (single-segment) identifiers used in expressions in this module
+    bare_idents:      HashSet<String>,
+    /// Whether the module has `use super::*`
+    has_super_glob:   bool,
+    /// Whether the module has a glob import other than `use super::*`
+    has_foreign_glob: bool
+}
+
+impl SymbolTable {
+    /// Records the names and glob imports a `use` statement introduces.
+    ///
+    /// # Arguments
+    ///
+    /// * `item` - The `use` statement to record
+    fn record_use(&mut self, item: &ItemUse) {
+        let mut prefix = Vec::new();
+        self.record_use_tree(&item.tree, &mut prefix);
+    }
+
+    /// Walks a use tree, recording bound names and glob imports.
+    ///
+    /// `use a::b::{self}` binds `b`, renames bind the new name, and globs set
+    /// the matching flag: `use super::*` inherits the parent scope, while any
+    /// other glob brings in names this analysis cannot enumerate.
+    ///
+    /// # Arguments
+    ///
+    /// * `tree` - Use tree node to walk
+    /// * `prefix` - Path segments accumulated above this node
+    fn record_use_tree(&mut self, tree: &UseTree, prefix: &mut Vec<String>) {
+        match tree {
+            UseTree::Path(path) => {
+                prefix.push(path.ident.to_string());
+                self.record_use_tree(&path.tree, prefix);
+                prefix.pop();
+            }
+            UseTree::Name(name) => {
+                let ident = name.ident.to_string();
+                if ident == "self" {
+                    if let Some(parent) = prefix.last() {
+                        self.bound.insert(parent.clone());
+                    }
+                } else {
+                    self.bound.insert(ident);
+                }
+            }
+            UseTree::Rename(rename) => {
+                self.bound.insert(rename.rename.to_string());
+            }
+            UseTree::Glob(_) => {
+                if prefix.len() == 1 && prefix[0] == "super" {
+                    self.has_super_glob = true;
+                } else {
+                    self.has_foreign_glob = true;
+                }
+            }
+            UseTree::Group(group) => {
+                for tree in &group.items {
+                    self.record_use_tree(tree, prefix);
+                }
+            }
+        }
+    }
+}
+
+/// Scope tree node: one module's symbols, rewrite candidates, and children.
+struct ModuleScope {
+    /// Names bound in and bare identifiers used by this module
+    symbols:       SymbolTable,
+    /// Byte offset at which to insert `use` statements for this module
+    insert_offset: Option<usize>,
+    /// Rewrite candidates found directly in this module
+    candidates:    Vec<Candidate>,
+    /// Inline child modules
+    children:      Vec<ModuleScope>
+}
+
+impl ModuleScope {
+    /// Builds the scope tree for a module's items.
+    ///
+    /// Inline child modules become child scopes; `use` statements and item
+    /// definitions populate the symbol table; function bodies are scanned for
+    /// rewrite candidates, bare identifier usage, and local bindings.
+    ///
+    /// # Arguments
+    ///
+    /// * `items` - Items of the module
+    /// * `insert_offset` - Byte offset for this module's `use` insertions
+    ///
+    /// # Returns
+    ///
+    /// The populated scope for this module and its descendants
+    fn build(items: &[Item], insert_offset: Option<usize>) -> Self {
+        let mut scope = Self {
+            symbols: SymbolTable::default(),
+            insert_offset,
+            candidates: Vec::new(),
+            children: Vec::new()
+        };
+
+        for item in items {
+            if let Item::Mod(module) = item {
+                scope.symbols.bound.insert(module.ident.to_string());
+                if let Some((_, child_items)) = &module.content {
+                    let child_offset = child_items
+                        .first()
+                        .map(|first| first.span().byte_range().start);
+                    scope.children.push(Self::build(child_items, child_offset));
+                }
+                continue;
+            }
+
+            let mut collector = BodyCollector {
+                scope: &mut scope
+            };
+            collector.visit_item(item);
+        }
+
+        scope
+    }
+
+    /// Final identifiers reachable from more than one distinct path here.
+    ///
+    /// Rewriting such an identifier would create ambiguous imports inside
+    /// this module, so those paths are left qualified.
+    ///
+    /// # Returns
+    ///
+    /// Set of ambiguous final identifiers
+    fn ambiguous_idents(&self) -> HashSet<String> {
+        let mut sources: HashMap<&str, &str> = HashMap::new();
+        let mut ambiguous = HashSet::new();
+
+        for candidate in &self.candidates {
+            match sources.get(candidate.ident.as_str()) {
+                Some(path) if *path != candidate.path.as_str() => {
+                    ambiguous.insert(candidate.ident.clone());
+                }
+                Some(_) => {}
+                None => {
+                    sources.insert(&candidate.ident, &candidate.path);
+                }
+            }
+        }
+
+        ambiguous
+    }
+
+    /// Whether importing a name here would rebind a descendant's bare usage.
+    ///
+    /// A descendant module reachable through a chain of `use super::*` globs
+    /// sees names imported here. If such a descendant already uses the name
+    /// bare without binding it itself, adding the import could silently
+    /// change what that usage resolves to.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Candidate import name to check
+    ///
+    /// # Returns
+    ///
+    /// `true` if a glob-inheriting descendant uses the name unbound
+    fn descendant_bare_conflict(&self, name: &str) -> bool {
+        self.children.iter().any(|child| {
+            child.symbols.has_super_glob
+                && ((child.symbols.bare_idents.contains(name)
+                    && !child.symbols.bound.contains(name))
+                    || child.descendant_bare_conflict(name))
+        })
+    }
+
+    /// Emits scope-safe suggestions for this module and its descendants.
+    ///
+    /// A candidate is rewritten only when its bare name is not already bound
+    /// in the effective scope (own names plus names inherited through
+    /// `use super::*`), is unambiguous among this module's candidates, and
+    /// cannot rebind a descendant's bare usage. Modules whose scope contains
+    /// a glob of unknown names produce no rewrites at all.
+    ///
+    /// # Arguments
+    ///
+    /// * `inherited_bound` - Names visible from ancestors via `use super::*`
+    /// * `inherited_foreign_glob` - Whether ancestors leak unknown glob names
+    /// * `suggestions` - Output collection
+    fn collect_suggestions(
+        &self,
+        inherited_bound: &HashSet<String>,
+        inherited_foreign_glob: bool,
+        suggestions: &mut Vec<Suggestion>
+    ) {
+        let foreign_glob = self.symbols.has_foreign_glob
+            || (self.symbols.has_super_glob && inherited_foreign_glob);
+
+        let mut visible = self.symbols.bound.clone();
+        if self.symbols.has_super_glob {
+            visible.extend(inherited_bound.iter().cloned());
+        }
+
+        if !foreign_glob && let Some(offset) = self.insert_offset {
+            let ambiguous = self.ambiguous_idents();
+
+            for candidate in &self.candidates {
+                if ambiguous.contains(&candidate.ident)
+                    || visible.contains(&candidate.ident)
+                    || self.descendant_bare_conflict(&candidate.ident)
+                {
+                    continue;
+                }
+
+                suggestions.push(Suggestion {
+                    edit:   TextEdit {
+                        range:       candidate.range.clone(),
+                        replacement: String::new()
+                    },
+                    import: Some(ImportEdit {
+                        offset,
+                        statement: format!("use {};", candidate.path)
+                    })
+                });
+            }
+        }
+
+        for child in &self.children {
+            child.collect_suggestions(&visible, foreign_glob, suggestions);
+        }
+    }
+}
+
+/// Scans one non-module item of a module for names and rewrite candidates.
+///
+/// Collects rewrite candidates, bare identifier usage, and local bindings
+/// into the owning [`ModuleScope`]. Function-local `use` statements are
+/// recorded conservatively as if module-level; function-local modules are
+/// left untouched (no candidates, no bindings).
+struct BodyCollector<'scope> {
+    /// Scope receiving the collected facts
+    scope: &'scope mut ModuleScope
+}
+
+impl<'scope, 'ast> Visit<'ast> for BodyCollector<'scope> {
+    fn visit_item(&mut self, node: &'ast Item) {
+        match node {
+            Item::Mod(_) => {}
+            Item::Use(item) => {
+                self.scope.symbols.record_use(item);
+            }
+            other => {
+                if let Some(name) = item_bound_name(other) {
+                    self.scope.symbols.bound.insert(name);
+                }
+                syn::visit::visit_item(self, node);
+            }
+        }
+    }
+
     fn visit_expr_path(&mut self, node: &'ast ExprPath) {
-        if node.qself.is_none()
-            && PathImportAnalyzer::should_extract_to_import(&node.path)
-            && let Some(last) = node.path.segments.last()
-        {
-            let ident = last.ident.to_string();
-            self.paths
-                .entry(ident)
-                .or_default()
-                .insert(path_to_string(&node.path));
+        if node.qself.is_none() {
+            if node.path.segments.len() == 1 {
+                if let Some(only) = node.path.segments.first() {
+                    self.scope
+                        .symbols
+                        .bare_idents
+                        .insert(only.ident.to_string());
+                }
+            } else if PathImportAnalyzer::should_extract_to_import(&node.path)
+                && let Some(last) = node.path.segments.last()
+            {
+                let path_start = node.path.span().byte_range().start;
+                let last_start = last.ident.span().byte_range().start;
+
+                if last_start > path_start {
+                    self.scope.candidates.push(Candidate {
+                        path:  path_to_string(&node.path),
+                        ident: last.ident.to_string(),
+                        range: path_start..last_start
+                    });
+                }
+            }
         }
 
         syn::visit::visit_expr_path(self, node);
+    }
+
+    fn visit_pat_ident(&mut self, node: &'ast syn::PatIdent) {
+        self.scope.symbols.bound.insert(node.ident.to_string());
+        syn::visit::visit_pat_ident(self, node);
     }
 }
 
@@ -259,12 +556,7 @@ impl PathVisitor {
             let span = path.span();
             let start = span.start();
 
-            let path_str = path
-                .segments
-                .iter()
-                .map(|s| s.ident.to_string())
-                .collect::<Vec<_>>()
-                .join("::");
+            let path_str = path_to_string(path);
 
             let function_name = path
                 .segments
@@ -286,48 +578,9 @@ impl PathVisitor {
     }
 }
 
-impl<'ast> syn::visit::Visit<'ast> for PathVisitor {
+impl<'ast> Visit<'ast> for PathVisitor {
     fn visit_expr_path(&mut self, node: &'ast ExprPath) {
         self.check_path(&node.path);
-        syn::visit::visit_expr_path(self, node);
-    }
-}
-
-/// Produces a fix suggestion for each qualified path that should be imported.
-///
-/// For each expression path that
-/// [`PathImportAnalyzer::should_extract_to_import`] approves and whose final
-/// identifier is not a short-name collision, a suggestion carries an edit
-/// deleting the leading segments (`std::fs::` in `std::fs::read`), leaving the
-/// final segment and its generic arguments untouched, plus the matching `use`.
-struct SuggestionVisitor {
-    suggestions: Vec<Suggestion>,
-    blocked:     HashSet<String>
-}
-
-impl<'ast> Visit<'ast> for SuggestionVisitor {
-    fn visit_expr_path(&mut self, node: &'ast ExprPath) {
-        if node.qself.is_none()
-            && PathImportAnalyzer::should_extract_to_import(&node.path)
-            && let Some(last) = node.path.segments.last()
-            && !self.blocked.contains(&last.ident.to_string())
-        {
-            let path_start = node.path.span().byte_range().start;
-            let last_start = last.ident.span().byte_range().start;
-
-            if last_start > path_start {
-                let path_str = path_to_string(&node.path);
-
-                self.suggestions.push(Suggestion {
-                    edit:   TextEdit {
-                        range:       path_start..last_start,
-                        replacement: String::new()
-                    },
-                    import: Some(format!("use {};", path_str))
-                });
-            }
-        }
-
         syn::visit::visit_expr_path(self, node);
     }
 }
@@ -439,17 +692,46 @@ mod tests {
     }
 
     #[test]
-    fn test_detect_module_paths_3plus_segments() {
+    fn test_ignore_relative_module_paths() {
         let analyzer = PathImportAnalyzer::new();
         let code: File = parse_quote! {
             fn main() {
-                let content = std::fs::read("file");
-                let data = std::io::stdin();
+                let data = helpers::io::load("file");
+                let more = my_mod::sub::func();
             }
         };
 
         let result = analyzer.analyze(&code, "").unwrap();
-        assert_eq!(result.issues.len(), 2);
+        assert_eq!(result.issues.len(), 0);
+    }
+
+    #[test]
+    fn test_ignore_super_and_self_paths() {
+        let analyzer = PathImportAnalyzer::new();
+        let code: File = parse_quote! {
+            mod inner {
+                fn f() {
+                    super::helpers::run();
+                    self::local::call();
+                }
+            }
+        };
+
+        let result = analyzer.analyze(&code, "").unwrap();
+        assert_eq!(result.issues.len(), 0);
+    }
+
+    #[test]
+    fn test_detect_crate_rooted_paths() {
+        let analyzer = PathImportAnalyzer::new();
+        let code: File = parse_quote! {
+            fn main() {
+                crate::util::helper();
+            }
+        };
+
+        let result = analyzer.analyze(&code, "").unwrap();
+        assert_eq!(result.issues.len(), 1);
     }
 
     #[test]
@@ -527,14 +809,14 @@ mod tests {
 
     #[test]
     fn test_fix_skips_short_name_collision() {
-        let content = "fn main() {\n    let a = std::fs::read(\"x\");\n    let b = other::helpers::read(\"y\");\n}\n";
+        let content = "fn main() {\n    let a = std::fs::read(\"x\");\n    let b = crate::helpers::read(\"y\");\n}\n";
         let (fixed, output) = apply_fix(content);
 
         assert_eq!(fixed, 0);
         assert!(output.contains("std::fs::read(\"x\")"));
-        assert!(output.contains("other::helpers::read(\"y\")"));
+        assert!(output.contains("crate::helpers::read(\"y\")"));
         assert!(!output.contains("use std::fs::read;"));
-        assert!(!output.contains("use other::helpers::read;"));
+        assert!(!output.contains("use crate::helpers::read;"));
     }
 
     #[test]
@@ -554,6 +836,104 @@ mod tests {
         assert_eq!(fixed, 1);
         assert!(output.contains("use core::mem::size_of;"));
         assert!(output.contains("size_of::<u32>()"));
+    }
+
+    #[test]
+    fn test_fix_skips_name_bound_by_existing_import() {
+        let content =
+            "use crate::util::read;\n\nfn main() {\n    let a = std::fs::read(\"x\");\n}\n";
+        let (fixed, output) = apply_fix(content);
+
+        assert_eq!(fixed, 0);
+        assert_eq!(output, content);
+    }
+
+    #[test]
+    fn test_fix_skips_already_imported_path() {
+        let content = "use std::fs::read;\n\nfn main() {\n    let a = std::fs::read(\"x\");\n}\n";
+        let (fixed, output) = apply_fix(content);
+
+        assert_eq!(fixed, 0);
+        assert_eq!(output, content);
+    }
+
+    #[test]
+    fn test_fix_skips_name_bound_by_local_fn() {
+        let content = "fn read(path: &str) -> &str {\n    path\n}\n\nfn main() {\n    let a = std::fs::read(\"x\");\n}\n";
+        let (fixed, output) = apply_fix(content);
+
+        assert_eq!(fixed, 0);
+        assert_eq!(output, content);
+    }
+
+    #[test]
+    fn test_fix_skips_name_bound_by_local_binding() {
+        let content = "fn main() {\n    let read = 1;\n    let a = std::fs::read(\"x\");\n    let _ = read;\n}\n";
+        let (fixed, output) = apply_fix(content);
+
+        assert_eq!(fixed, 0);
+        assert_eq!(output, content);
+    }
+
+    #[test]
+    fn test_fix_skips_module_with_foreign_glob() {
+        let content = "use helpers::*;\n\nfn main() {\n    let a = std::fs::read(\"x\");\n}\n";
+        let (fixed, output) = apply_fix(content);
+
+        assert_eq!(fixed, 0);
+        assert_eq!(output, content);
+    }
+
+    #[test]
+    fn test_fix_inserts_import_into_nested_module() {
+        let content = "fn top() {\n    let a = std::fs::read_to_string(\"a\");\n}\n\nmod inner {\n    fn f() {\n        let b = std::fs::read_to_string(\"b\");\n    }\n}\n";
+        let (fixed, output) = apply_fix(content);
+
+        assert_eq!(fixed, 2);
+        assert_eq!(output.matches("use std::fs::read_to_string;").count(), 2);
+        assert!(!output.contains("std::fs::read_to_string("));
+        let import_pos = output.find("mod inner").unwrap();
+        assert!(
+            output[import_pos..].contains("use std::fs::read_to_string;"),
+            "nested module receives its own import"
+        );
+    }
+
+    #[test]
+    fn test_fix_respects_names_inherited_via_super_glob() {
+        let content = "fn read() {}\n\nmod inner {\n    use super::*;\n\n    fn f() {\n        let x = std::fs::read(\"f\");\n    }\n}\n";
+        let (fixed, output) = apply_fix(content);
+
+        assert_eq!(fixed, 0);
+        assert_eq!(output, content);
+    }
+
+    #[test]
+    fn test_fix_skips_when_descendant_uses_name_bare() {
+        let content = "fn parent_call() {\n    let a = std::fs::read(\"f\");\n}\n\nmod inner {\n    use super::*;\n\n    fn g() {\n        read(\"x\");\n    }\n}\n";
+        let (fixed, output) = apply_fix(content);
+
+        assert_eq!(fixed, 0);
+        assert_eq!(output, content);
+    }
+
+    #[test]
+    fn test_fix_allows_test_module_with_super_glob() {
+        let content = "fn top() {\n    let a = std::fs::read_to_string(\"a\");\n}\n\nmod tests {\n    use super::*;\n\n    fn t() {\n        let b = std::fs::read_to_string(\"b\");\n    }\n}\n";
+        let (fixed, output) = apply_fix(content);
+
+        assert_eq!(fixed, 2);
+        assert!(!output.contains("std::fs::read_to_string("));
+    }
+
+    #[test]
+    fn test_fix_crate_rooted_path() {
+        let content = "fn main() {\n    crate::util::helper();\n}\n";
+        let (fixed, output) = apply_fix(content);
+
+        assert_eq!(fixed, 1);
+        assert!(output.contains("use crate::util::helper;"));
+        assert!(output.contains("    helper();"));
     }
 
     #[test]
@@ -619,26 +999,12 @@ mod tests {
         let analyzer = PathImportAnalyzer::new();
         let code: File = parse_quote! {
             fn main() {
-                let x = some::module::MAX_VALUE;
+                let x = std::u32::MAX_VALUE;
             }
         };
 
         let result = analyzer.analyze(&code, "").unwrap();
         assert_eq!(result.issues.len(), 0);
-    }
-
-    #[test]
-    fn test_path_with_generics() {
-        let analyzer = PathImportAnalyzer::new();
-        let code: File = parse_quote! {
-            fn main() {
-                let content = std::fs::read_to_string("file.txt");
-                let data = std::io::stdin();
-            }
-        };
-
-        let result = analyzer.analyze(&code, "").unwrap();
-        assert!(!result.issues.is_empty());
     }
 
     #[test]

--- a/src/differ/apply.rs
+++ b/src/differ/apply.rs
@@ -142,7 +142,7 @@ mod tests {
         let path = temp.path().join("d.rs");
         fs::write(
             &path,
-            "fn main() {\n    let a = std::fs::read(\"x\");\n    let b = other::helpers::read(\"y\");\n}\n"
+            "fn main() {\n    let a = std::fs::read(\"x\");\n    let b = crate::helpers::read(\"y\");\n}\n"
         )
         .unwrap();
 

--- a/src/differ/display.rs
+++ b/src/differ/display.rs
@@ -287,7 +287,7 @@ pub fn show_interactive(result: &DiffResult, color: bool) -> AppResult<DiffResul
                 println!("{}", format!("- {}", entry.original).red());
 
                 if let Some(import) = &entry.import {
-                    println!("{}", format!("+ {}", import).green());
+                    println!("{}", format!("+ {}", import.statement).green());
                 }
 
                 println!("{}", format!("+ {}", entry.modified).green());
@@ -297,7 +297,7 @@ pub fn show_interactive(result: &DiffResult, color: bool) -> AppResult<DiffResul
                 println!("- {}", entry.original);
 
                 if let Some(import) = &entry.import {
-                    println!("+ {}", import);
+                    println!("+ {}", import.statement);
                 }
 
                 println!("+ {}", entry.modified);

--- a/src/differ/display/render.rs
+++ b/src/differ/display/render.rs
@@ -126,14 +126,14 @@ fn render_imports(lines: &mut Vec<String>, max_width: &mut usize, file: &FileDif
     let imports: Vec<&str> = file
         .entries
         .iter()
-        .filter_map(|e| e.import.as_deref())
+        .filter_map(|e| e.import.as_ref().map(|i| i.statement.as_str()))
         .collect();
 
     if imports.is_empty() {
         return;
     }
 
-    let import_header = "Imports (file top)";
+    let import_header = "Imports";
     *max_width = (*max_width).max(measure_text_width(import_header));
 
     if color {
@@ -335,7 +335,7 @@ fn render_footer(lines: &mut Vec<String>, max_width: &mut usize, color: bool) {
 mod tests {
     use super::*;
     use crate::{
-        analyzer::TextEdit,
+        analyzer::{ImportEdit, TextEdit},
         differ::types::{DiffEntry, FileDiff}
     };
 
@@ -374,7 +374,10 @@ mod tests {
             original:    "std::fs::read()".to_string(),
             modified:    "read()".to_string(),
             description: "Use import".to_string(),
-            import:      Some("use std::fs::read;".to_string()),
+            import:      Some(ImportEdit {
+                offset:    0,
+                statement: "use std::fs::read;".to_string()
+            }),
             edit:        TextEdit::default()
         });
 

--- a/src/differ/types.rs
+++ b/src/differ/types.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
-use crate::analyzer::TextEdit;
+use crate::analyzer::{ImportEdit, TextEdit};
 
 /// Represents a single code change.
 ///
@@ -15,7 +15,7 @@ pub struct DiffEntry {
     pub original:    String,
     pub modified:    String,
     pub description: String,
-    pub import:      Option<String>,
+    pub import:      Option<ImportEdit>,
     pub edit:        TextEdit
 }
 

--- a/src/fixer.rs
+++ b/src/fixer.rs
@@ -8,15 +8,16 @@
 //! comments, blank lines, and the author's formatting are preserved — unlike
 //! reprinting the AST, which drops comments and reformats the whole file.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
 use crate::analyzer::{Suggestion, TextEdit};
 
 /// Applies fix suggestions to the source, deduplicating their imports.
 ///
 /// Collects each suggestion's rewrite edit, inserts every distinct required
-/// import once at the top of the file, and applies them via [`apply_edits`].
-/// Comments, blank lines, and formatting outside the edits are preserved.
+/// import once at its target offset — the module that must receive it — and
+/// applies them via [`apply_edits`]. Comments, blank lines, and formatting
+/// outside the edits are preserved.
 ///
 /// # Arguments
 ///
@@ -30,18 +31,20 @@ pub fn apply_suggestions(source: &str, suggestions: &[Suggestion]) -> String {
     let mut edits: Vec<TextEdit> = suggestions.iter().map(|s| s.edit.clone()).collect();
 
     let mut seen = HashSet::new();
-    let mut imports = Vec::new();
+    let mut grouped: BTreeMap<usize, Vec<&str>> = BTreeMap::new();
     for suggestion in suggestions {
         if let Some(import) = &suggestion.import
-            && seen.insert(import.clone())
+            && seen.insert((import.offset, import.statement.as_str()))
         {
-            imports.push(import.clone());
+            grouped
+                .entry(import.offset)
+                .or_default()
+                .push(import.statement.as_str());
         }
     }
 
-    if !imports.is_empty() {
-        let offset = import_insertion_offset(source);
-        let mut block = imports.join("\n");
+    for (offset, statements) in grouped {
+        let mut block = statements.join("\n");
         block.push('\n');
         edits.push(TextEdit {
             range:       offset..offset,


### PR DESCRIPTION
Closes #104.

The `path_import` auto-fix rewrote qualified paths to bare names with no scope awareness, which produced duplicate imports, unresolved names in test modules, and calls silently rebinding to unrelated functions (217 compile errors on a real codebase).

Root-cause fixes:

- **Absolute paths only.** Extraction now accepts only paths rooted at `std`, `core`, `alloc`, or `crate`. Relative paths (including `self::` and `super::`) resolve against the module they appear in, so hoisting them into a `use` statement changed their meaning.
- **Per-module symbol table.** Suggestions are built from a scope tree of the file: names bound by items, `use` statements (including renames and `{self}`), and local bindings; glob imports are tracked, with `use super::*` inheriting the parent scope and any other glob suppressing rewrites in that module since its names cannot be enumerated.
- **Per-module import insertion.** The `use` statement is inserted into the module containing the rewritten path — top of file for top-level code, first item of an inline module otherwise — so the bare name is always in scope at the rewrite site. `ImportEdit` now carries the target offset and the fix engine groups and deduplicates insertions per offset.
- **Rebinding guards.** A rewrite is skipped when the bare name is already bound in the effective scope, is ambiguous among the module's own candidates, or is used bare by a `use super::*` descendant that does not bind it itself (importing it would silently change what that usage resolves to).

Tests cover each failure mode: existing-import collision, already-imported path, local fn/binding shadowing, foreign glob suppression, nested-module insertion, super-glob inheritance, descendant bare-usage guard, and relative/`super::`/`self::` path rejection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Import suggestions now support precise insertion points within nested modules.
  * Imports are grouped and deduplicated by location, reducing duplicate or misplaced edits.
* **Bug Fixes**
  * Improved scope analysis to avoid unsafe suggestions involving name collisions, ambiguity, glob imports, and local bindings.
  * Suggestions now focus on supported absolute paths while rejecting relative or unrelated module paths.
* **Improvements**
  * Import changes are displayed more clearly in interactive and standard diff output.
  * Import sections now use a shorter, clearer heading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->