### PR TITLE
#111 chore: bump version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cargo-quality"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-quality"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["RAprogramm <andrey.rozanov.vl@gmail.com>"]
 description = "Professional Rust code quality analysis tool with hardcoded standards"


### PR DESCRIPTION
Closes #111.

Releases the analyzer autofix work from #109: `empty_lines` and `inline_comments` now emit suggestions applied by `cargo qual fix` and `cargo qual diff`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 0.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->