### PR TITLE
#113 docs: regenerate README with cargo-rdme 2.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ binary, ensuring uniform analysis across your entire codebase.
 
 This library provides:
 
-- **[`analyzer`](https://docs.rs/cargo-quality/latest/cargo_quality/analyzer/)** - Core trait and types for building analyzers
-- **[`analyzers`](https://docs.rs/cargo-quality/latest/cargo_quality/analyzers/)** - Built-in analyzers for common code quality issues
-- **[`formatter`](https://docs.rs/cargo-quality/latest/cargo_quality/formatter/)** - Code formatting with hardcoded standards
-- **[`differ`](https://docs.rs/cargo-quality/latest/cargo_quality/differ/)** - Diff generation and visualization
-- **[`report`](https://docs.rs/cargo-quality/latest/cargo_quality/report/)** - Analysis report generation
-- **[`error`](https://docs.rs/cargo-quality/latest/cargo_quality/error/)** - Error types for quality operations
+- **`analyzer`** - Core trait and types for building analyzers
+- **`analyzers`** - Built-in analyzers for common code quality issues
+- **`formatter`** - Code formatting with hardcoded standards
+- **`differ`** - Diff generation and visualization
+- **`report`** - Analysis report generation
+- **`error`** - Error types for quality operations
 
 ### Quick Start
 
@@ -83,19 +83,15 @@ assert!(result.issues[0].diagnostic.message.contains("Use import"));
 
 | Analyzer | Description |
 |----------|-------------|
-| [`PathImportAnalyzer`] | Detects `std::fs::read` paths that should use `use` |
-| [`FormatArgsAnalyzer`] | Finds `println!("{}", x)` that should use `{x}` |
-| [`EmptyLinesAnalyzer`] | Finds empty lines in function bodies |
-| [`InlineCommentsAnalyzer`] | Finds `//` comments that should be `///` |
+| `PathImportAnalyzer` | Detects `std::fs::read` paths that should use `use` |
+| `FormatArgsAnalyzer` | Finds `println!("{}", x)` that should use `{x}` |
+| `EmptyLinesAnalyzer` | Finds empty lines in function bodies |
+| `InlineCommentsAnalyzer` | Finds `//` comments that should be `///` |
 
-[`PathImportAnalyzer`]: https://docs.rs/cargo-quality/latest/cargo_quality/analyzers/path_import/struct.PathImportAnalyzer.html
-[`FormatArgsAnalyzer`]: https://docs.rs/cargo-quality/latest/cargo_quality/analyzers/format_args/struct.FormatArgsAnalyzer.html
-[`EmptyLinesAnalyzer`]: https://docs.rs/cargo-quality/latest/cargo_quality/analyzers/empty_lines/struct.EmptyLinesAnalyzer.html
-[`InlineCommentsAnalyzer`]: https://docs.rs/cargo-quality/latest/cargo_quality/analyzers/inline_comments/struct.InlineCommentsAnalyzer.html
 
 ### Running All Analyzers
 
-Use [`analyzers::default_analyzers()`](https://docs.rs/cargo-quality/latest/cargo_quality/analyzers/fn.default_analyzers.html) to get all built-in analyzers:
+Use `analyzers::default_analyzers()` to get all built-in analyzers:
 
 ```rust
 use cargo_quality::{analyzer::Analyzer, analyzers::default_analyzers};
@@ -115,7 +111,7 @@ for analyzer in default_analyzers() {
 
 ### Custom Analyzers
 
-Implement the [`analyzer::Analyzer`](https://docs.rs/cargo-quality/latest/cargo_quality/analyzer/trait.Analyzer.html) trait to create custom analyzers:
+Implement the `analyzer::Analyzer` trait to create custom analyzers:
 
 ```rust
 use cargo_quality::analyzer::{AnalysisResult, Analyzer};


### PR DESCRIPTION
Closes #113.

The Documentation job installs cargo-rdme@latest; 2.2.1 drops intralink references under `--intralinks-strip-links` instead of rewriting them to docs.rs URLs. Regenerating the README with the same version restores the sync check and unblocks the 0.6.0 release run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed external documentation links from the module list, analyzer table, and custom analyzer trait reference.
  * Updated these references to display as plain text or code formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->